### PR TITLE
Reduce error message from Roslyn analyser

### DIFF
--- a/Sia.CodeGenerators/Properties/launchSettings.json
+++ b/Sia.CodeGenerators/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "DebugRoslynSourceGenerator": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "../Sia.Examples/Sia.Examples.csproj"
+    }
+  }
+}

--- a/Sia.CodeGenerators/Sia.CodeGenerators.csproj
+++ b/Sia.CodeGenerators/Sia.CodeGenerators.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
@@ -15,10 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="$(OutputPath)\netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
 </Project>

--- a/Sia.Examples/Sia.Examples.csproj
+++ b/Sia.Examples/Sia.Examples.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
   


### PR DESCRIPTION
Closes #5

1. Remove `<IncludeBuildOutput>false</IncludeBuildOutput>` let is pack automatically. (It should make the same effect, because net8.0 not publish anyway)
2. Remove `<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>` because we can track the generated code from IDE.