### PR TITLE
Fix compiler Error CS8157 #21

### DIFF
--- a/Sia.CodeGenerators/SiaPropertyGenerator.cs
+++ b/Sia.CodeGenerators/SiaPropertyGenerator.cs
@@ -331,7 +331,7 @@ internal partial class SiaPropertyGenerator : IIncrementalGenerator
 
         source.WriteLine("public void Execute(global::Sia.World _, global::Sia.Entity target)");
         source.Indent++;
-        source.Write("=> Execute(ref target.Get<");
+        source.Write("=> Execute(ref target.GetRef<");
         WriteComponentType();
         source.WriteLine(">());");
         source.Indent--;
@@ -384,7 +384,7 @@ internal partial class SiaPropertyGenerator : IIncrementalGenerator
         source.WriteLine('{');
         source.Indent++;
 
-        source.Write("ref var component = ref target.Get<");
+        source.Write("ref var component = ref target.GetRef<");
         WriteComponentType();
         source.WriteLine(">();");
 
@@ -433,7 +433,7 @@ internal partial class SiaPropertyGenerator : IIncrementalGenerator
         source.WriteLine("private readonly global::Sia.World _world = world ?? global::Sia.Context<global::Sia.World>.Current!;");
         source.Write("private readonly ref ");
         WriteComponentType();
-        source.Write(" _component = ref entity.Get<");
+        source.Write(" _component = ref entity.GetRef<");
         WriteComponentType();
         source.WriteLine(">();");
 

--- a/Sia.CodeGenerators/SiaTemplateGenerator.cs
+++ b/Sia.CodeGenerators/SiaTemplateGenerator.cs
@@ -240,7 +240,7 @@ internal partial class SiaTemplateGenerator : IIncrementalGenerator
 
         source.WriteLine("public void Execute(global::Sia.World _, global::Sia.Entity target)");
         source.Indent++;
-        source.Write("=> target.Get<");
+        source.Write("=> target.GetRef<");
         source.Write(componentName);
         WriteTypeParameters(source, templateType);
         source.WriteLine(">() = new(Value);");

--- a/Sia.Examples/Example11_RPG.cs
+++ b/Sia.Examples/Example11_RPG.cs
@@ -32,7 +32,7 @@ public static partial class Example11_RPG
             {
                 float damage = metadata.BaseDamage + Random.Shared.NextSingle() * 10f;
 
-                ref var attackerCharacter = ref attacker.Get<Character>();
+                var attackerCharacter = attacker.Get<Character>();
                 if (attackerCharacter.MP > 10f) {
                     attackerCharacter.MP -= 10f;
                     damage += 20f;
@@ -86,12 +86,12 @@ public static partial class Example11_RPG
                 float defense;
 
                 try {
-                    ref var attackerMeta = ref Attacker.Get<CharacterMetadata>();
-                    ref var attackerCharacter = ref Attacker.Get<Character>();
+                    var attackerMeta = Attacker.Get<CharacterMetadata>();
+                    var attackerCharacter = Attacker.Get<Character>();
                     damage = attackerMeta.BaseDamage + attackerCharacter.Level * attackerMeta.DamageGrowthRate;
 
                     if (attackerCharacter.Weapon is Entity weapon) {
-                        ref var weaponMeta = ref weapon.Get<WeaponMetadata>();
+                        var weaponMeta = weapon.Get<WeaponMetadata>();
                         damage += weaponMeta.DamageProvider.GetDamage(weaponMeta, Attacker, self);
                     }
                 }
@@ -101,7 +101,7 @@ public static partial class Example11_RPG
                 }
 
                 try {
-                    ref var selfMeta = ref self.Get<CharacterMetadata>();
+                    var selfMeta = self.Get<CharacterMetadata>();
 
                     var selfCharacter = new View(self);
                     defense = selfMeta.BaseDefense + selfCharacter.Level * selfMeta.DefenseGrowthRate;
@@ -128,7 +128,7 @@ public static partial class Example11_RPG
         public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
         {
             foreach (var entity in query) {
-                ref var character = ref entity.Get<Character>();
+                var character = entity.Get<Character>();
                 if (character.HP <= 0) {
                     Console.WriteLine(character.Name + " is dead!");
                     entity.Dispose();

--- a/Sia.Examples/Example16_EventSystem.cs
+++ b/Sia.Examples/Example16_EventSystem.cs
@@ -13,7 +13,7 @@ public static partial class Example16_EventSystem
         public readonly record struct TestCommand : ICommand
         {
             public void Execute(World world, Entity target)
-                => target.Get<Position>().X++;
+                => target.GetRef<Position>().X++;
         }
     }
 

--- a/Sia.Examples/Example1_HealthDamage.cs
+++ b/Sia.Examples/Example1_HealthDamage.cs
@@ -45,7 +45,7 @@ public static partial class Example1_HealthDamage
             var game = world.GetAddon<Game>();
 
             foreach (var entity in query) {
-                ref var health = ref entity.Get<Health>();
+                var health = entity.Get<Health>();
                 if (health.Debuff != 0) {
                     entity.Modify(new Health.Damage(health.Debuff * game.DeltaTime));
                 }

--- a/Sia.Examples/Example2_HealthRecover.cs
+++ b/Sia.Examples/Example2_HealthRecover.cs
@@ -14,7 +14,7 @@ public static class Example2_HealthRecover
         public readonly record struct Damage(int Value) : ICommand
         {
             public void Execute(World _, Entity target)
-                => target.Get<HP>().Value -= Value;
+                => target.GetRef<HP>().Value -= Value;
         }
 
         public sealed class Kill : SingletonEvent<Kill>, ICancellableEvent;
@@ -26,7 +26,7 @@ public static class Example2_HealthRecover
         public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
         {
             foreach (var entity in query) {
-                ref var hp = ref entity.Get<HP>();
+                ref var hp = ref entity.GetRef<HP>();
 
                 if (hp.Value < hp.Maximum) {
                     hp.Value = Math.Min(hp.Value + hp.AutoRecoverRate, hp.Maximum);
@@ -61,7 +61,7 @@ public static class Example2_HealthRecover
             Console.WriteLine("START KILLING!");
 
             foreach (var entity in query) {
-                entity.Get<HP>().Value = 0;
+                entity.GetRef<HP>().Value = 0;
                 Console.WriteLine("KILL!");
             }
         }
@@ -89,7 +89,7 @@ public static class Example2_HealthRecover
             .RegisterTo(world, scheduler);
 
         var player = Player.CreateResilient(world, "玩家");
-        ref var hp = ref player.Get<HP>();
+        ref var hp = ref player.GetRef<HP>();
 
         Console.WriteLine("HP: " + hp.Value);
         scheduler.Tick();

--- a/Sia.Examples/Example4_Aggregator.cs
+++ b/Sia.Examples/Example4_Aggregator.cs
@@ -18,7 +18,7 @@ public static partial class Example4_Aggregator
         public override void Execute(World world, Scheduler scheduler, IEntityQuery query)
         {
             foreach (var entity in query) {
-                ref var aggr = ref entity.Get<Aggregation<ObjectId>>();
+                var aggr = entity.Get<Aggregation<ObjectId>>();
                 int count = aggr.Group.Count;
                 Console.WriteLine($"[{aggr.Id}] Count: " + count);
             }

--- a/Sia.Examples/Tests.cs
+++ b/Sia.Examples/Tests.cs
@@ -14,7 +14,7 @@ public record struct Position(float X, float Y, float Z)
     {
         public void Execute(World world, Entity target)
         {
-            ref var pos = ref target.Get<Position>();
+            ref var pos = ref target.GetRef<Position>();
             pos.X = X;
             pos.Y = Y;
             pos.Z = Z;

--- a/Sia.Reactors/Aggregator/Aggregator.cs
+++ b/Sia.Reactors/Aggregator/Aggregator.cs
@@ -25,7 +25,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
         };
         
         Listen((Entity entity, in WorldEvents.Add<Aggregation<TId>> e) => {
-            ref var aggr = ref entity.Get<Aggregation<TId>>();
+            ref var aggr = ref entity.GetRef<Aggregation<TId>>();
             if (aggr.Aggregator != this) {
                 return;
             }
@@ -34,7 +34,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
         });
 
         Listen((Entity entity, in WorldEvents.Remove<Aggregation<TId>> e) => {
-            ref var aggr = ref entity.Get<Aggregation<TId>>();
+            ref var aggr = ref entity.GetRef<Aggregation<TId>>();
             if (aggr.Aggregator != this) {
                 return;
             }
@@ -64,7 +64,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
 
     private void OnAggregationCreated(Entity entity)
     {
-        ref var aggr = ref entity.Get<Aggregation<TId>>();
+        ref var aggr = ref entity.GetRef<Aggregation<TId>>();
         if (_aggrs.TryAdd(aggr.Id, entity)) {
             aggr.Aggregator = this;
         }
@@ -72,7 +72,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
 
     private void OnAggregationReleased(Entity entity)
     {
-        ref var aggr = ref entity.Get<Aggregation<TId>>();
+        ref var aggr = ref entity.GetRef<Aggregation<TId>>();
         _aggrs.Remove(aggr.Id, out var removedEntity);
         if (removedEntity != entity)  {
             _aggrs.Add(aggr.Id, removedEntity!);
@@ -84,7 +84,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
 
     private bool OnEntityIdChanged(Entity entity, in Sid<TId>.SetValue e)
     {
-        ref var id = ref entity.Get<Sid<TId>>();
+        ref var id = ref entity.GetRef<Sid<TId>>();
         RemoveFromAggregation(entity, id.Previous);
         AddToAggregation(entity, id.Value);
         return false;
@@ -112,14 +112,14 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
         if (!exists) {
             aggrEntity = CreateAggregationEntity();
 
-            ref var aggr = ref aggrEntity.Get<Aggregation<TId>>();
+            ref var aggr = ref aggrEntity.GetRef<Aggregation<TId>>();
             aggr.Id = id;
             aggr.First = entity;
             aggr._group = _groupPool.TryPop(out var pooled) ? pooled : [];
             aggr._group.Add(entity);
         }
         else {
-            aggrEntity!.Get<Aggregation<TId>>()._group!.Add(entity);
+            aggrEntity!.GetRef<Aggregation<TId>>()._group!.Add(entity);
         }
 
         World.Send(aggrEntity, new Aggregation<TId>.EntityAdded(entity));
@@ -133,7 +133,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
             return;
         }
 
-        ref var aggr = ref aggrEntity.Get<Aggregation<TId>>();
+        ref var aggr = ref aggrEntity.GetRef<Aggregation<TId>>();
         var group = aggr._group!;
 
         if (!group.Remove(entity)) {

--- a/Sia.Reactors/Hierarchy/Hierarchy.cs
+++ b/Sia.Reactors/Hierarchy/Hierarchy.cs
@@ -14,7 +14,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
         base.OnInitialize(world);
         
         Listen((Entity entity, in Node<TTag>.SetParent cmd) => {
-            ref var node = ref entity.Get<Node<TTag>>();
+            ref var node = ref entity.GetRef<Node<TTag>>();
 
             var parent = node.Parent;
             var previousParent = node._prevParent;
@@ -40,7 +40,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
         });
 
         Listen((Entity entity, in Node<TTag>.SetIsSelfEnabled cmd) => {
-            ref var node = ref entity.Get<Node<TTag>>();
+            ref var node = ref entity.GetRef<Node<TTag>>();
             SetIsEnabledRecursively(entity, ref node,
                 node.Parent == null || node.Parent.Get<Node<TTag>>().IsEnabled);
         });
@@ -59,7 +59,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
 
         if (node._children != null) {
             foreach (var child in node._children) {
-                ref var childNode = ref child.Get<Node<TTag>>();
+                ref var childNode = ref child.GetRef<Node<TTag>>();
                 SetIsEnabledRecursively(child, ref childNode, enabled);
             }
         }
@@ -67,7 +67,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
 
     protected override void OnEntityAdded(Entity entity)
     {
-        ref var node = ref entity.Get<Node<TTag>>();
+        ref var node = ref entity.GetRef<Node<TTag>>();
         var parent = node.Parent;
         if (parent != null) {
             AddToParent(entity, parent);
@@ -79,7 +79,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
 
     protected override void OnEntityRemoved(Entity entity)
     {
-        ref var node = ref entity.Get<Node<TTag>>();
+        ref var node = ref entity.GetRef<Node<TTag>>();
 
         var parent = node.Parent;
         if (parent != null) {
@@ -102,7 +102,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private Entity AddToParent(Entity entity, Entity parent)
     {
-        ref var parentNode = ref parent.Get<Node<TTag>>();
+        ref var parentNode = ref parent.GetRef<Node<TTag>>();
         ref var children = ref parentNode._children;
 
         children ??= _childrenPool.TryPop(out var pooled) ? pooled : [];
@@ -115,7 +115,7 @@ public class Hierarchy<TTag> : ReactorBase<TypeUnion<Node<TTag>>>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void RemoveFromParent(Entity entity, in Entity parent)
     {
-        ref var parentNode = ref parent.Get<Node<TTag>>();
+        ref var parentNode = ref parent.GetRef<Node<TTag>>();
         ref var children = ref parentNode._children;
 
         children!.Remove(entity);

--- a/Sia.Reactors/Mapper/Mapper.cs
+++ b/Sia.Reactors/Mapper/Mapper.cs
@@ -24,7 +24,7 @@ public class Mapper<TId> : ReactorBase<TypeUnion<Sid<TId>>>, IReadOnlyDictionary
 
     private bool OnEntityIdChanged(Entity entity, in Sid<TId>.SetValue e)
     {
-        ref var id = ref entity.Get<Sid<TId>>();
+        var id = entity.Get<Sid<TId>>();
         RemoveMap(entity, id.Previous);
         AddMap(entity, id.Value);
         return false;

--- a/Sia.Tests/Auxiliary/ContextTests.cs
+++ b/Sia.Tests/Auxiliary/ContextTests.cs
@@ -51,6 +51,27 @@ public class ContextTests
     }
 
     [Fact]
+    public void Context_With_Test()
+    {
+        // Arrange
+        const string value1 = "Value1";
+        const string value2 = "Value2";
+        var result = string.Empty;
+
+        Context<string>.Current = value1;
+
+        Context<string>.With(value1, () =>
+        {
+            Context<string>.Current = value2;
+            result = value2;
+        });
+
+        // Act
+        Assert.Equal(value2, result);
+        Assert.Equal(value1, Context<string>.Current);
+    }
+
+    [Fact]
     public void Context_IJobAssign_Test()
     {
         // Arrange

--- a/Sia.Tests/Auxiliary/TypeUnionTests.cs
+++ b/Sia.Tests/Auxiliary/TypeUnionTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Numerics;
-
-namespace Sia.Tests.Auxiliary;
+﻿namespace Sia.Tests.Auxiliary;
 
 public class TypeUnionTests
 {
@@ -8,20 +6,24 @@ public class TypeUnionTests
     [
         [new TypeUnion<bool>()],
         [new TypeUnion<bool, byte>()],
-        [new TypeUnion<bool, byte, sbyte>()],
-        [new TypeUnion<bool, byte, sbyte, short>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal, char>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal, char, string>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal, char, string, Guid>()],
-        [new TypeUnion<bool, byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal, char, string, Guid, Vector<string>>()]
+        [new TypeUnion<bool, byte>()],
+        [new TypeUnion<bool, byte, short>()],
+        [new TypeUnion<bool, byte, short>()],
+        [new TypeUnion<bool, byte, short, int>()],
+        [new TypeUnion<bool, byte, short, int>()],
+        [new TypeUnion<bool, byte, short, int, long>()],
+        [new TypeUnion<bool, byte, short, int, long>()],
+        [new TypeUnion<bool, byte, short, int, long, float>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string, object>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string, object, dynamic>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string, object, dynamic, Action<float>>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string, object, dynamic, Action<float>, TypeCode>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string, object, dynamic, Action<float>, TypeCode, Guid>()],
+        [new TypeUnion<bool, byte, short, int, long, float, double, decimal, char, string, object, dynamic, Action<float>, TypeCode, Guid, Random>()]
     ];
 
     [Theory]

--- a/Sia.Tests/Components/ComponentsTests.cs
+++ b/Sia.Tests/Components/ComponentsTests.cs
@@ -13,8 +13,8 @@ public class ComponentsTests
 
         var entityRef = fixture.World.CreateInArrayHost(Transform.BakedEntity);
 
-        ref var position = ref entityRef.Get<Position>();
-        ref var rotation = ref entityRef.Get<Rotation>();
+        ref var position = ref entityRef.GetRef<Position>();
+        ref var rotation = ref entityRef.GetRef<Rotation>();
 
         Assert.Equal(Vector3.Zero, position, (a, b) =>
             Math.Abs(a.Value.X - b.Value.X) < Epsilon &&

--- a/Sia.Tests/Components/Transform.cs
+++ b/Sia.Tests/Components/Transform.cs
@@ -37,7 +37,7 @@ public partial record struct Transform([Sia] Position Position, [Sia] Rotation R
 
         public void Execute(World _, Entity target)
         {
-            ref var quaternion = ref target.Get<Rotation>();
+            ref var quaternion = ref target.GetRef<Rotation>();
             var a = Euler * (MathF.PI / 180.0f);
             var s = Sin(a * 0.5f);
             var c = Cos(a * 0.5f);

--- a/Sia.Tests/Reactors/AggregatorTests.cs
+++ b/Sia.Tests/Reactors/AggregatorTests.cs
@@ -60,7 +60,7 @@ public class AggregatorTests(AggregatorTests.AggregatorContext context) : IClass
         // Assert
         var actualResult = new List<AggregatorContext.ObjectId>();
         foreach (var entity in context.World.Query(Matchers.Of<Aggregation<AggregatorContext.ObjectId>>())) {
-            ref var aggregation = ref entity.Get<Aggregation<AggregatorContext.ObjectId>>();
+            var aggregation = entity.Get<Aggregation<AggregatorContext.ObjectId>>();
             actualResult.Add(aggregation.Id);
         }
         Assert.Contains(objectId, actualResult);

--- a/Sia/Entities/Entity.cs
+++ b/Sia/Entities/Entity.cs
@@ -57,22 +57,33 @@ public sealed record Entity : IDisposable
         => Descriptor.Offsets.ContainsKey(componentType);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref TComponent Get<TComponent>()
+    public TComponent Get<TComponent>()
     {
         ref var byteRef = ref Host.UnsafeGetByteRef(Slot);
         nint offset = Descriptor.GetOffset<TComponent>();
-        return ref Unsafe.As<byte, TComponent>(
+        return Unsafe.As<byte, TComponent>(
             ref Unsafe.AddByteOffset(ref byteRef, offset));
     }
     
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref TComponent GetRef<TComponent>()
+    {
+        ref var byteRef = ref Host.UnsafeGetByteRef(Slot);
+        nint offset = Descriptor.GetOffset<TComponent>();
+        ref var component = ref Unsafe.As<byte, TComponent>(
+            ref Unsafe.AddByteOffset(ref byteRef, offset));
+        return ref Unsafe.AsRef(ref component);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref TComponent GetOrNullRef<TComponent>()
     {
         ref var byteRef = ref Host.UnsafeGetByteRef(Slot);
         try {
             nint offset = Descriptor.GetOffset<TComponent>();
-            return ref Unsafe.As<byte, TComponent>(
+            ref var component = ref Unsafe.As<byte, TComponent>(
                 ref Unsafe.AddByteOffset(ref byteRef, offset));
+            return ref Unsafe.AsRef(ref component);
         }
         catch {
             return ref Unsafe.NullRef<TComponent>();

--- a/Sia/Entities/Relation.cs
+++ b/Sia/Entities/Relation.cs
@@ -69,7 +69,7 @@ public static class RelationExtensions
         this Entity entity, out TArgRelation arg)
         where TArgRelation : IRelation
     {
-        ref var relation = ref entity.Get<ArgRelation<TArgRelation>>();
+        ref var relation = ref entity.GetRef<ArgRelation<TArgRelation>>();
         arg = relation.Relation;
         return relation.Target;
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Try fix the compiler error CS8157 [MS Explain](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8157). Here we use `Unsafe.AsRef` to make sure compiler understand function return is a reference not value.

Closes #21 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
