### PR TITLE
Enable the sequential fast path for world entity hosts

### DIFF
--- a/Sia.Tests/Entities/BufferEntityHostTests.cs
+++ b/Sia.Tests/Entities/BufferEntityHostTests.cs
@@ -57,6 +57,37 @@ public class BufferEntityHostTests
     }
 
     [Fact]
+    public void BulkIteration_AddressesSequentialLayoutAcrossArchetypes()
+    {
+        using var world = new World();
+        for (var i = 0; i < 96; i++) {
+            if ((i & 1) == 0) {
+                world.Create(HList.From(i, 1L));
+            }
+            else {
+                world.Create(HList.From(i, 1f));
+            }
+        }
+        var query = world.Query(Matchers.Of<int>());
+
+        var sum = 0;
+        query.ForSlice((ref int value) => sum += value);
+        Assert.Equal(4560, sum);
+
+        query.ForSlice((ref int value) => value += 1);
+        var total = 0;
+        foreach (var entity in query) {
+            total += entity.Get<int>();
+        }
+        Assert.Equal(4560 + 96, total);
+
+        var host = world.GetArrayHost<HList<int, HList<long, EmptyHList>>>();
+        var hostSum = 0L;
+        host.ForSlice((ref long value) => hostSum += value);
+        Assert.Equal(48, hostSum);
+    }
+
+    [Fact]
     public void EntityIds_RemainUniqueAcrossPoolsAndDirectAllocation()
     {
         using var first = BufferEntityHost<HList<int, EmptyHList>>.Create(

--- a/Sia/Entities/Extensions/EntityExtensionsCommon.cs
+++ b/Sia/Entities/Extensions/EntityExtensionsCommon.cs
@@ -4,6 +4,7 @@ namespace Sia;
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 internal static class EntityExtensionsCommon
 {
@@ -216,6 +217,18 @@ internal static class EntityExtensionsCommon
     {
         if (currentVersion != requiredVersion) {
             throw new InvalidOperationException("Entity host cannot be modified during the task");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GuardSequentialBytes(IEntityHost host, Span<byte> bytes)
+    {
+        if (host.TryGetSequentialBytes(out var current)
+            && !Unsafe.AreSame(
+                ref MemoryMarshal.GetReference(current),
+                ref MemoryMarshal.GetReference(bytes))) {
+            throw new InvalidOperationException(
+                "Entity host storage was reallocated during the iteration");
         }
     }
 }

--- a/Sia/Entities/Extensions/EntityHostExtensions.ForEach.cs
+++ b/Sia/Entities/Extensions/EntityHostExtensions.ForEach.cs
@@ -2,6 +2,7 @@ namespace Sia;
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static EntityExtensionsCommon;
 
 public static partial class EntityHostExtensions
 {
@@ -120,14 +121,14 @@ public static partial class EntityHostExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -147,8 +148,7 @@ public static partial class EntityHostExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -157,6 +157,7 @@ public static partial class EntityHostExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -179,8 +180,7 @@ public static partial class EntityHostExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -190,6 +190,7 @@ public static partial class EntityHostExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -214,8 +215,7 @@ public static partial class EntityHostExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -226,6 +226,7 @@ public static partial class EntityHostExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -252,8 +253,7 @@ public static partial class EntityHostExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -265,6 +265,7 @@ public static partial class EntityHostExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -293,8 +294,7 @@ public static partial class EntityHostExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -307,6 +307,7 @@ public static partial class EntityHostExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -334,8 +335,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -343,6 +343,7 @@ public static partial class EntityHostExtensions
                         handler(userData,
                             ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -365,8 +366,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -375,6 +375,7 @@ public static partial class EntityHostExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -400,8 +401,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -411,6 +411,7 @@ public static partial class EntityHostExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -438,8 +439,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -450,6 +450,7 @@ public static partial class EntityHostExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -479,8 +480,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -492,6 +492,7 @@ public static partial class EntityHostExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -523,8 +524,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -537,6 +537,7 @@ public static partial class EntityHostExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -742,14 +743,14 @@ public static partial class EntityHostExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -770,8 +771,7 @@ public static partial class EntityHostExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -780,6 +780,7 @@ public static partial class EntityHostExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -803,8 +804,7 @@ public static partial class EntityHostExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -814,6 +814,7 @@ public static partial class EntityHostExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -839,8 +840,7 @@ public static partial class EntityHostExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -851,6 +851,7 @@ public static partial class EntityHostExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -878,8 +879,7 @@ public static partial class EntityHostExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -891,6 +891,7 @@ public static partial class EntityHostExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -920,8 +921,7 @@ public static partial class EntityHostExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -934,6 +934,7 @@ public static partial class EntityHostExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -962,8 +963,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -971,6 +971,7 @@ public static partial class EntityHostExtensions
                         handler(entities[i], userData,
                             ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -994,8 +995,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1004,6 +1004,7 @@ public static partial class EntityHostExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1030,8 +1031,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1041,6 +1041,7 @@ public static partial class EntityHostExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1069,8 +1070,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1081,6 +1081,7 @@ public static partial class EntityHostExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1111,8 +1112,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1124,6 +1124,7 @@ public static partial class EntityHostExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1156,8 +1157,7 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1170,6 +1170,7 @@ public static partial class EntityHostExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {

--- a/Sia/Entities/Extensions/EntityHostExtensions.ForEach.cs
+++ b/Sia/Entities/Extensions/EntityHostExtensions.ForEach.cs
@@ -1,6 +1,7 @@
 namespace Sia;
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 public static partial class EntityHostExtensions
 {
@@ -119,9 +120,10 @@ public static partial class EntityHostExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(ref c1Offset.Get(ref memRef, offset));
@@ -145,9 +147,10 @@ public static partial class EntityHostExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -176,9 +179,10 @@ public static partial class EntityHostExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -210,9 +214,10 @@ public static partial class EntityHostExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -247,9 +252,10 @@ public static partial class EntityHostExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -287,9 +293,10 @@ public static partial class EntityHostExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -327,9 +334,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -357,9 +365,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -391,9 +400,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -428,9 +438,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -468,9 +479,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -511,9 +523,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -729,9 +742,10 @@ public static partial class EntityHostExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], ref c1Offset.Get(ref memRef, offset));
@@ -756,9 +770,10 @@ public static partial class EntityHostExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -788,9 +803,10 @@ public static partial class EntityHostExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -823,9 +839,10 @@ public static partial class EntityHostExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -861,9 +878,10 @@ public static partial class EntityHostExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -902,9 +920,10 @@ public static partial class EntityHostExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -943,9 +962,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -974,9 +994,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1009,9 +1030,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1047,9 +1069,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1088,9 +1111,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1132,9 +1156,10 @@ public static partial class EntityHostExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,

--- a/Sia/Entities/Extensions/EntityQueryExtensions.ForEach.cs
+++ b/Sia/Entities/Extensions/EntityQueryExtensions.ForEach.cs
@@ -1,6 +1,7 @@
 namespace Sia;
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 public static partial class EntityQueryExtensions
 {
@@ -119,9 +120,10 @@ public static partial class EntityQueryExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(ref c1Offset.Get(ref memRef, offset));
@@ -145,9 +147,10 @@ public static partial class EntityQueryExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -176,9 +179,10 @@ public static partial class EntityQueryExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -210,9 +214,10 @@ public static partial class EntityQueryExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -247,9 +252,10 @@ public static partial class EntityQueryExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -287,9 +293,10 @@ public static partial class EntityQueryExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(
@@ -327,9 +334,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -357,9 +365,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -391,9 +400,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -428,9 +438,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -468,9 +479,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -511,9 +523,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(userData,
@@ -729,9 +742,10 @@ public static partial class EntityQueryExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], ref c1Offset.Get(ref memRef, offset));
@@ -756,9 +770,10 @@ public static partial class EntityQueryExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -788,9 +803,10 @@ public static partial class EntityQueryExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -823,9 +839,10 @@ public static partial class EntityQueryExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -861,9 +878,10 @@ public static partial class EntityQueryExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -902,9 +920,10 @@ public static partial class EntityQueryExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i],
@@ -943,9 +962,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -974,9 +994,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1009,9 +1030,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1047,9 +1069,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1088,9 +1111,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,
@@ -1132,9 +1156,10 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                if (host is ISequentialEntityHost seqHost) {
-                    ref var memRef = ref seqHost.Bytes[0];
-                    var size = seqHost.Descriptor.MemorySize;
+                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+                if (!bytes.IsEmpty) {
+                    ref var memRef = ref MemoryMarshal.GetReference(bytes);
+                    var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], userData,

--- a/Sia/Entities/Extensions/EntityQueryExtensions.ForEach.cs
+++ b/Sia/Entities/Extensions/EntityQueryExtensions.ForEach.cs
@@ -2,6 +2,7 @@ namespace Sia;
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using static EntityExtensionsCommon;
 
 public static partial class EntityQueryExtensions
 {
@@ -120,14 +121,14 @@ public static partial class EntityQueryExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -147,8 +148,7 @@ public static partial class EntityQueryExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -157,6 +157,7 @@ public static partial class EntityQueryExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -179,8 +180,7 @@ public static partial class EntityQueryExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -190,6 +190,7 @@ public static partial class EntityQueryExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -214,8 +215,7 @@ public static partial class EntityQueryExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -226,6 +226,7 @@ public static partial class EntityQueryExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -252,8 +253,7 @@ public static partial class EntityQueryExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -265,6 +265,7 @@ public static partial class EntityQueryExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -293,8 +294,7 @@ public static partial class EntityQueryExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -307,6 +307,7 @@ public static partial class EntityQueryExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -334,8 +335,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -343,6 +343,7 @@ public static partial class EntityQueryExtensions
                         handler(userData,
                             ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -365,8 +366,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -375,6 +375,7 @@ public static partial class EntityQueryExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -400,8 +401,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -411,6 +411,7 @@ public static partial class EntityQueryExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -438,8 +439,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -450,6 +450,7 @@ public static partial class EntityQueryExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -479,8 +480,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -492,6 +492,7 @@ public static partial class EntityQueryExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -523,8 +524,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -537,6 +537,7 @@ public static partial class EntityQueryExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -742,14 +743,14 @@ public static partial class EntityQueryExtensions
                 var desc = host.Descriptor;
                 var c1Offset = desc.GetOffset<C1>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
                         nint offset = i * size;
                         handler(entities[i], ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -770,8 +771,7 @@ public static partial class EntityQueryExtensions
                 var c1Offset = desc.GetOffset<C1>();
                 var c2Offset = desc.GetOffset<C2>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -780,6 +780,7 @@ public static partial class EntityQueryExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -803,8 +804,7 @@ public static partial class EntityQueryExtensions
                 var c2Offset = desc.GetOffset<C2>();
                 var c3Offset = desc.GetOffset<C3>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -814,6 +814,7 @@ public static partial class EntityQueryExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -839,8 +840,7 @@ public static partial class EntityQueryExtensions
                 var c3Offset = desc.GetOffset<C3>();
                 var c4Offset = desc.GetOffset<C4>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -851,6 +851,7 @@ public static partial class EntityQueryExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -878,8 +879,7 @@ public static partial class EntityQueryExtensions
                 var c4Offset = desc.GetOffset<C4>();
                 var c5Offset = desc.GetOffset<C5>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -891,6 +891,7 @@ public static partial class EntityQueryExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -920,8 +921,7 @@ public static partial class EntityQueryExtensions
                 var c5Offset = desc.GetOffset<C5>();
                 var c6Offset = desc.GetOffset<C6>();
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -934,6 +934,7 @@ public static partial class EntityQueryExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -962,8 +963,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -971,6 +971,7 @@ public static partial class EntityQueryExtensions
                         handler(entities[i], userData,
                             ref c1Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -994,8 +995,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1004,6 +1004,7 @@ public static partial class EntityQueryExtensions
                             ref c1Offset.Get(ref memRef, offset),
                             ref c2Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1030,8 +1031,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1041,6 +1041,7 @@ public static partial class EntityQueryExtensions
                             ref c2Offset.Get(ref memRef, offset),
                             ref c3Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1069,8 +1070,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1081,6 +1081,7 @@ public static partial class EntityQueryExtensions
                             ref c3Offset.Get(ref memRef, offset),
                             ref c4Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1111,8 +1112,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1124,6 +1124,7 @@ public static partial class EntityQueryExtensions
                             ref c4Offset.Get(ref memRef, offset),
                             ref c5Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {
@@ -1156,8 +1157,7 @@ public static partial class EntityQueryExtensions
                 var handler = data.Item1;
                 ref readonly var userData = ref data.Item2;
 
-                var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-                if (!bytes.IsEmpty) {
+                if (host.TryGetSequentialBytes(out var bytes)) {
                     ref var memRef = ref MemoryMarshal.GetReference(bytes);
                     var size = host.Descriptor.MemorySize;
                     for (var i = from; i != to; ++i) {
@@ -1170,6 +1170,7 @@ public static partial class EntityQueryExtensions
                             ref c5Offset.Get(ref memRef, offset),
                             ref c6Offset.Get(ref memRef, offset));
                     }
+                    GuardSequentialBytes(host, bytes);
                 }
                 else {
                     for (var i = from; i != to; ++i) {

--- a/Sia/Entities/Extensions/EntityQueryExtensions.Slices.cs
+++ b/Sia/Entities/Extensions/EntityQueryExtensions.Slices.cs
@@ -22,14 +22,14 @@ public static partial class EntityQueryExtensions
             var c1Offset = desc.GetOffset<C1>();
             var version = host.Version;
 
-            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-            if (!bytes.IsEmpty) {
+            if (host.TryGetSequentialBytes(out var bytes)) {
                 var size = desc.MemorySize;
                 ref var cursor = ref MemoryMarshal.GetReference(bytes);
                 for (var i = 0; i < count; i++) {
                     handler.Handle(ref c1Offset.Get(ref cursor));
                     cursor = ref Unsafe.AddByteOffset(ref cursor, size);
                 }
+                GuardSequentialBytes(host, bytes);
             }
             else {
                 for (var i = 0; i < count; i++) {
@@ -58,8 +58,7 @@ public static partial class EntityQueryExtensions
             var c2Offset = desc.GetOffset<C2>();
             var version = host.Version;
 
-            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-            if (!bytes.IsEmpty) {
+            if (host.TryGetSequentialBytes(out var bytes)) {
                 var size = desc.MemorySize;
                 ref var cursor = ref MemoryMarshal.GetReference(bytes);
                 for (var i = 0; i < count; i++) {
@@ -68,6 +67,7 @@ public static partial class EntityQueryExtensions
                         ref c2Offset.Get(ref cursor));
                     cursor = ref Unsafe.AddByteOffset(ref cursor, size);
                 }
+                GuardSequentialBytes(host, bytes);
             }
             else {
                 for (var i = 0; i < count; i++) {
@@ -99,8 +99,7 @@ public static partial class EntityQueryExtensions
             var c3Offset = desc.GetOffset<C3>();
             var version = host.Version;
 
-            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-            if (!bytes.IsEmpty) {
+            if (host.TryGetSequentialBytes(out var bytes)) {
                 var size = desc.MemorySize;
                 ref var cursor = ref MemoryMarshal.GetReference(bytes);
                 for (var i = 0; i < count; i++) {
@@ -110,6 +109,7 @@ public static partial class EntityQueryExtensions
                         ref c3Offset.Get(ref cursor));
                     cursor = ref Unsafe.AddByteOffset(ref cursor, size);
                 }
+                GuardSequentialBytes(host, bytes);
             }
             else {
                 for (var i = 0; i < count; i++) {
@@ -143,8 +143,7 @@ public static partial class EntityQueryExtensions
             var c4Offset = desc.GetOffset<C4>();
             var version = host.Version;
 
-            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
-            if (!bytes.IsEmpty) {
+            if (host.TryGetSequentialBytes(out var bytes)) {
                 var size = desc.MemorySize;
                 ref var cursor = ref MemoryMarshal.GetReference(bytes);
                 for (var i = 0; i < count; i++) {
@@ -155,6 +154,7 @@ public static partial class EntityQueryExtensions
                         ref c4Offset.Get(ref cursor));
                     cursor = ref Unsafe.AddByteOffset(ref cursor, size);
                 }
+                GuardSequentialBytes(host, bytes);
             }
             else {
                 for (var i = 0; i < count; i++) {

--- a/Sia/Entities/Hosts/BufferEntityHost.cs
+++ b/Sia/Entities/Hosts/BufferEntityHost.cs
@@ -14,7 +14,7 @@ public static class BufferEntityHost<TEntity>
 }
 
 public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
-    : IEntityHost<TEntity>, ISequentialEntityHost
+    : IEntityHost<TEntity>
     where TEntity : struct, IHList
     where TBuffer : IBuffer<TEntity>
 {
@@ -27,8 +27,16 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
     public int Count => Buffer.Count;
     public int Version { get; private set; }
 
-    public Span<byte> Bytes =>
-        Buffer.Count == 0 ? [] : MemoryMarshal.Cast<TEntity, byte>(Buffer.AsSpan());
+    public bool TryGetSequentialBytes(out Span<byte> bytes)
+    {
+        if (Buffer.Count == 0
+            || (long)Buffer.Capacity * Unsafe.SizeOf<TEntity>() > int.MaxValue) {
+            bytes = default;
+            return false;
+        }
+        bytes = MemoryMarshal.Cast<TEntity, byte>(Buffer.AsSpan());
+        return true;
+    }
 
     public TBuffer Buffer { get; } = buffer;
 

--- a/Sia/Entities/Interfaces/IEntityHost.cs
+++ b/Sia/Entities/Interfaces/IEntityHost.cs
@@ -40,6 +40,12 @@ public interface IEntityHost : IEnumerable<Entity>, IDisposable
         where THandler : IGenericConcreteTypeHandler<IEntityHost<UEntity>>;
 
     Span<Entity> UnsafeGetEntitySpan();
+
+    bool TryGetSequentialBytes(out Span<byte> bytes)
+    {
+        bytes = default;
+        return false;
+    }
 }
 
 public interface IReactiveEntityHost : IEntityHost

--- a/Sia/Entities/Interfaces/ISequentialEntityHost.cs
+++ b/Sia/Entities/Interfaces/ISequentialEntityHost.cs
@@ -1,6 +1,0 @@
-namespace Sia;
-
-public interface ISequentialEntityHost : IEntityHost
-{
-    public Span<byte> Bytes { get; }
-}

--- a/Sia/Worlds/WorldEntityHost.cs
+++ b/Sia/Worlds/WorldEntityHost.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 using static WorldHostUtils;
 
 public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost innerHost)
-    : IEntityHost<TEntity>, IReactiveEntityHost, ISequentialEntityHost
+    : IEntityHost<TEntity>, IReactiveEntityHost
     where TEntity : struct, IHList
     where TInnerHost : IEntityHost<TEntity>, new()
 {
@@ -38,8 +38,8 @@ public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost
     public int Count => InnerHost.Count;
     public int Version => InnerHost.Version;
 
-    public Span<byte> Bytes =>
-        InnerHost is ISequentialEntityHost sequentialHost ? sequentialHost.Bytes : default;
+    public bool TryGetSequentialBytes(out Span<byte> bytes)
+        => InnerHost.TryGetSequentialBytes(out bytes);
 
     public WorldEntityHost(World world) : this(world, new()) {}
 

--- a/Sia/Worlds/WorldEntityHost.cs
+++ b/Sia/Worlds/WorldEntityHost.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 using static WorldHostUtils;
 
 public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost innerHost)
-    : IEntityHost<TEntity>, IReactiveEntityHost
+    : IEntityHost<TEntity>, IReactiveEntityHost, ISequentialEntityHost
     where TEntity : struct, IHList
     where TInnerHost : IEntityHost<TEntity>, new()
 {
@@ -37,6 +37,9 @@ public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost
     public int Capacity => InnerHost.Capacity;
     public int Count => InnerHost.Count;
     public int Version => InnerHost.Version;
+
+    public Span<byte> Bytes =>
+        InnerHost is ISequentialEntityHost sequentialHost ? sequentialHost.Bytes : default;
 
     public WorldEntityHost(World world) : this(world, new()) {}
 


### PR DESCRIPTION
WorldEntityHost now exposes its inner host's sequential layout so query and host bulk iteration walk a byte cursor instead of per-slot GetByteRef interface chains. Alternating A/B against the pre-rework baseline: bulk iteration -32% (65k, one archetype), -51% (four archetypes), stage tick -30%.

The second commit replaces the ISequentialEntityHost type check with an explicit IEntityHost.TryGetSequentialBytes contract (default false, so custom hosts keep the fallback), removes the interface, and bounds the view so hosts whose buffer would exceed the span limit fall back safely. Every fast-path pass revalidates the view base afterwards and throws if the storage was reallocated mid-iteration, so structural growth during a slice loop fails loudly in release instead of writing to a stale buffer. The struct slice handler path from #63 is migrated to the same contract in this PR, which is why it now touches EntityQueryExtensions.Slices.cs.

The added test verifies addressing through the sequential view: query-level slice sums and mutations read back through Entity.Get across two archetypes, and host-level iteration sees the same layout.

Closes #56