### PR TITLE
Add struct slice handler iteration api

### DIFF
--- a/Sia.Benchmarks/Entities/QueryIterationBenchmarks.cs
+++ b/Sia.Benchmarks/Entities/QueryIterationBenchmarks.cs
@@ -52,4 +52,17 @@ public class QueryIterationBenchmarks
         return _first.Get<Position>().X;
     }
 
+    [Benchmark]
+    public float SliceIterationStructHandler()
+    {
+        var handler = new MovementHandler();
+        _query.ForSlice<Position, Velocity, MovementHandler>(ref handler);
+        return _first.Get<Position>().X;
+    }
+
+    private struct MovementHandler : ISliceHandler<Position, Velocity>
+    {
+        public readonly void Handle(ref Position position, ref Velocity velocity)
+            => position.X += velocity.X;
+    }
 }

--- a/Sia.Tests/Entities/EntityExtensionsTests.cs
+++ b/Sia.Tests/Entities/EntityExtensionsTests.cs
@@ -41,6 +41,27 @@ public class EntityExtensionsTests
         }));
     }
 
+    private struct SliceSumHandler : ISliceHandler<Sid<ObjectId>>
+    {
+        public int Sum;
+
+        public void Handle(ref Sid<ObjectId> id) => Sum += id.Value.Value;
+    }
+
+    [Fact]
+    public void QueryForSlice_StructHandler_Test()
+    {
+        using var world = new World();
+        for (var i = 0; i < 32; i++) {
+            world.Create(HList.From(new Sid<ObjectId>(i)));
+        }
+        var query = world.Query(Matchers.Of<Sid<ObjectId>>());
+
+        var handler = new SliceSumHandler();
+        query.ForSlice<Sid<ObjectId>, SliceSumHandler>(ref handler);
+        Assert.Equal(496, handler.Sum);
+    }
+
     [Fact]
     public void EntityHostRecord_Test()
     {

--- a/Sia/Components/Interfaces/ISliceHandler.cs
+++ b/Sia/Components/Interfaces/ISliceHandler.cs
@@ -1,0 +1,31 @@
+namespace Sia;
+
+public interface ISliceHandler<C1>
+{
+    void Handle(ref C1 c1);
+}
+
+public interface ISliceHandler<C1, C2>
+{
+    void Handle(ref C1 c1, ref C2 c2);
+}
+
+public interface ISliceHandler<C1, C2, C3>
+{
+    void Handle(ref C1 c1, ref C2 c2, ref C3 c3);
+}
+
+public interface ISliceHandler<C1, C2, C3, C4>
+{
+    void Handle(ref C1 c1, ref C2 c2, ref C3 c3, ref C4 c4);
+}
+
+public interface ISliceHandler<C1, C2, C3, C4, C5>
+{
+    void Handle(ref C1 c1, ref C2 c2, ref C3 c3, ref C4 c4, ref C5 c5);
+}
+
+public interface ISliceHandler<C1, C2, C3, C4, C5, C6>
+{
+    void Handle(ref C1 c1, ref C2 c2, ref C3 c3, ref C4 c4, ref C5 c5, ref C6 c6);
+}

--- a/Sia/Entities/Extensions/EntityQueryExtensions.Slices.cs
+++ b/Sia/Entities/Extensions/EntityQueryExtensions.Slices.cs
@@ -1,0 +1,172 @@
+namespace Sia;
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static EntityExtensionsCommon;
+
+public static partial class EntityQueryExtensions
+{
+    public static void ForSlice<C1, THandler>(
+        this IEntityQuery query, ref THandler handler)
+        where THandler : ISliceHandler<C1>
+    {
+        var hosts = query.Hosts;
+        var hostCount = hosts.Count;
+        for (var h = 0; h < hostCount; h++) {
+            var host = hosts[h];
+            var count = host.Count;
+            if (count == 0) {
+                continue;
+            }
+            var desc = host.Descriptor;
+            var c1Offset = desc.GetOffset<C1>();
+            var version = host.Version;
+
+            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+            if (!bytes.IsEmpty) {
+                var size = desc.MemorySize;
+                ref var cursor = ref MemoryMarshal.GetReference(bytes);
+                for (var i = 0; i < count; i++) {
+                    handler.Handle(ref c1Offset.Get(ref cursor));
+                    cursor = ref Unsafe.AddByteOffset(ref cursor, size);
+                }
+            }
+            else {
+                for (var i = 0; i < count; i++) {
+                    ref var byteRef = ref host.GetByteRef(i);
+                    handler.Handle(ref c1Offset.Get(ref byteRef));
+                }
+            }
+            GuardVersion(version, host.Version);
+        }
+    }
+
+    public static void ForSlice<C1, C2, THandler>(
+        this IEntityQuery query, ref THandler handler)
+        where THandler : ISliceHandler<C1, C2>
+    {
+        var hosts = query.Hosts;
+        var hostCount = hosts.Count;
+        for (var h = 0; h < hostCount; h++) {
+            var host = hosts[h];
+            var count = host.Count;
+            if (count == 0) {
+                continue;
+            }
+            var desc = host.Descriptor;
+            var c1Offset = desc.GetOffset<C1>();
+            var c2Offset = desc.GetOffset<C2>();
+            var version = host.Version;
+
+            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+            if (!bytes.IsEmpty) {
+                var size = desc.MemorySize;
+                ref var cursor = ref MemoryMarshal.GetReference(bytes);
+                for (var i = 0; i < count; i++) {
+                    handler.Handle(
+                        ref c1Offset.Get(ref cursor),
+                        ref c2Offset.Get(ref cursor));
+                    cursor = ref Unsafe.AddByteOffset(ref cursor, size);
+                }
+            }
+            else {
+                for (var i = 0; i < count; i++) {
+                    ref var byteRef = ref host.GetByteRef(i);
+                    handler.Handle(
+                        ref c1Offset.Get(ref byteRef),
+                        ref c2Offset.Get(ref byteRef));
+                }
+            }
+            GuardVersion(version, host.Version);
+        }
+    }
+
+    public static void ForSlice<C1, C2, C3, THandler>(
+        this IEntityQuery query, ref THandler handler)
+        where THandler : ISliceHandler<C1, C2, C3>
+    {
+        var hosts = query.Hosts;
+        var hostCount = hosts.Count;
+        for (var h = 0; h < hostCount; h++) {
+            var host = hosts[h];
+            var count = host.Count;
+            if (count == 0) {
+                continue;
+            }
+            var desc = host.Descriptor;
+            var c1Offset = desc.GetOffset<C1>();
+            var c2Offset = desc.GetOffset<C2>();
+            var c3Offset = desc.GetOffset<C3>();
+            var version = host.Version;
+
+            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+            if (!bytes.IsEmpty) {
+                var size = desc.MemorySize;
+                ref var cursor = ref MemoryMarshal.GetReference(bytes);
+                for (var i = 0; i < count; i++) {
+                    handler.Handle(
+                        ref c1Offset.Get(ref cursor),
+                        ref c2Offset.Get(ref cursor),
+                        ref c3Offset.Get(ref cursor));
+                    cursor = ref Unsafe.AddByteOffset(ref cursor, size);
+                }
+            }
+            else {
+                for (var i = 0; i < count; i++) {
+                    ref var byteRef = ref host.GetByteRef(i);
+                    handler.Handle(
+                        ref c1Offset.Get(ref byteRef),
+                        ref c2Offset.Get(ref byteRef),
+                        ref c3Offset.Get(ref byteRef));
+                }
+            }
+            GuardVersion(version, host.Version);
+        }
+    }
+
+    public static void ForSlice<C1, C2, C3, C4, THandler>(
+        this IEntityQuery query, ref THandler handler)
+        where THandler : ISliceHandler<C1, C2, C3, C4>
+    {
+        var hosts = query.Hosts;
+        var hostCount = hosts.Count;
+        for (var h = 0; h < hostCount; h++) {
+            var host = hosts[h];
+            var count = host.Count;
+            if (count == 0) {
+                continue;
+            }
+            var desc = host.Descriptor;
+            var c1Offset = desc.GetOffset<C1>();
+            var c2Offset = desc.GetOffset<C2>();
+            var c3Offset = desc.GetOffset<C3>();
+            var c4Offset = desc.GetOffset<C4>();
+            var version = host.Version;
+
+            var bytes = host is ISequentialEntityHost seqHost ? seqHost.Bytes : default;
+            if (!bytes.IsEmpty) {
+                var size = desc.MemorySize;
+                ref var cursor = ref MemoryMarshal.GetReference(bytes);
+                for (var i = 0; i < count; i++) {
+                    handler.Handle(
+                        ref c1Offset.Get(ref cursor),
+                        ref c2Offset.Get(ref cursor),
+                        ref c3Offset.Get(ref cursor),
+                        ref c4Offset.Get(ref cursor));
+                    cursor = ref Unsafe.AddByteOffset(ref cursor, size);
+                }
+            }
+            else {
+                for (var i = 0; i < count; i++) {
+                    ref var byteRef = ref host.GetByteRef(i);
+                    handler.Handle(
+                        ref c1Offset.Get(ref byteRef),
+                        ref c2Offset.Get(ref byteRef),
+                        ref c3Offset.Get(ref byteRef),
+                        ref c4Offset.Get(ref byteRef));
+                }
+            }
+            GuardVersion(version, host.Version);
+        }
+    }
+}


### PR DESCRIPTION
Adds ISliceHandler interfaces (arity 1-6) and ForSlice overloads that take a struct handler by ref, so the JIT devirtualizes and inlines the per-entity body instead of paying a delegate call. Sequential hosts iterate with a running byte cursor; other hosts keep the per-slot fallback, and the debug-only version guard matches the delegate path. Stateful handlers work since the struct is passed by ref end to end.

Measured ~7% under the delegate path on the 65k movement loop; a SliceIterationStructHandler benchmark is added alongside the existing delegate benchmark for tracking.

Closes #57