### PR TITLE
Retry opfs mount instead of failing notebook boot

### DIFF
--- a/Sia.Examples/Browser/OpfsMount.cs
+++ b/Sia.Examples/Browser/OpfsMount.cs
@@ -7,16 +7,29 @@ namespace Sia_Examples.Browser;
 public static partial class OpfsMount
 {
     private const int OpfsDirectoryMode = 0x1FF; // 0777
+    private const int MaxAttempts = 3;
 
     public static async Task<bool> MountAsync(string path)
     {
-        var result = await Task.Run(() => {
-            var backend = NativeMethods.wasmfs_create_opfs_backend();
-            return backend == nint.Zero
-                ? -1
-                : NativeMethods.wasmfs_create_directory(path, OpfsDirectoryMode, backend);
-        });
-        return result == 0;
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++) {
+            if (attempt > 1) {
+                await Task.Delay(50 * (attempt - 1));
+            }
+            try {
+                var result = await Task.Run(() => {
+                    var backend = NativeMethods.wasmfs_create_opfs_backend();
+                    return backend == nint.Zero
+                        ? -1
+                        : NativeMethods.wasmfs_create_directory(path, OpfsDirectoryMode, backend);
+                });
+                if (result == 0) {
+                    return true;
+                }
+            }
+            catch {
+            }
+        }
+        return false;
     }
 
     private static partial class NativeMethods

--- a/Sia.Examples/Elements/BrowserApplication.cs
+++ b/Sia.Examples/Elements/BrowserApplication.cs
@@ -10,7 +10,15 @@ public static class BrowserApplication
     {
         const string NotebooksPath = "/notebooks";
 
-        await OpfsMount.MountAsync(NotebooksPath);
+        await Task.Delay(16);
+        try {
+            if (!await OpfsMount.MountAsync(NotebooksPath)) {
+                Console.Error.WriteLine("OPFS unavailable; notebooks won't persist this session.");
+            }
+        }
+        catch (Exception error) {
+            Console.Error.WriteLine($"OPFS mount failed: {error.Message}");
+        }
 
         var mainThread = BrowserMainThread.Capture();
         var resources = new BrowserResourceLoader(mainThread);


### PR DESCRIPTION
Fixes #90.

Delays the OPFS mount briefly so the browser main thread can go idle first, retries with backoff, and degrades gracefully to in-memory storage instead of taking down the whole app boot.