### PR TITLE
Persist notebooks to IndexedDB instead of OPFS

### DIFF
--- a/Sia.Examples/Browser/IndexedDbNotebookStorage.cs
+++ b/Sia.Examples/Browser/IndexedDbNotebookStorage.cs
@@ -1,0 +1,121 @@
+#if BROWSER
+using System.Runtime.InteropServices.JavaScript;
+using System.Text.Json;
+using System.Xml;
+using Sia_Examples.Notebook;
+
+namespace Sia_Examples.Browser;
+
+public sealed partial class IndexedDbNotebookStorage(BrowserMainThread mainThread) : INotebookStorage
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public async ValueTask<IReadOnlyList<NotebookStorageEntry>> ListAsync(
+        CancellationToken cancellationToken = default)
+    {
+        mainThread.VerifyAccess();
+        var json = await GetAllJsonAsync();
+        mainThread.VerifyAccess();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var records = JsonSerializer.Deserialize<RawRecord[]>(json, JsonOptions) ?? [];
+        List<NotebookStorageEntry> entries = [];
+        foreach (var record in records) {
+            if (TryDescribe(record) is { } entry) {
+                entries.Add(entry);
+            }
+        }
+        return [.. entries.OrderByDescending(static entry => entry.SavedAt)];
+    }
+
+    public async ValueTask<NotebookContent?> LoadAsync(
+        string key, CancellationToken cancellationToken = default)
+    {
+        mainThread.VerifyAccess();
+        var json = await GetJsonAsync(key);
+        mainThread.VerifyAccess();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (json is null) {
+            return null;
+        }
+        var record = JsonSerializer.Deserialize<RawRecord>(json, JsonOptions)!;
+        return new NotebookContent(record.Xml, NotebookVersioning.ComputeVersion(record.Xml));
+    }
+
+    public async ValueTask<NotebookSaveResult> SaveAsync(
+        string? key, string? expectedVersion, string xml,
+        CancellationToken cancellationToken = default)
+    {
+        mainThread.VerifyAccess();
+        key ??= NewKey();
+        await CheckVersionAsync(key, expectedVersion);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await PutAsync(key, xml, DateTimeOffset.UtcNow.ToString("O"));
+        mainThread.VerifyAccess();
+        return new NotebookSaveResult(key, NotebookVersioning.ComputeVersion(xml));
+    }
+
+    public async ValueTask DeleteAsync(
+        string key, string expectedVersion, CancellationToken cancellationToken = default)
+    {
+        mainThread.VerifyAccess();
+        await CheckVersionAsync(key, expectedVersion);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await RemoveAsync(key);
+        mainThread.VerifyAccess();
+    }
+
+    private static async Task CheckVersionAsync(string key, string? expectedVersion)
+    {
+        if (expectedVersion is not { } expected) {
+            return;
+        }
+        var json = await GetJsonAsync(key);
+        var actual = json is null
+            ? null
+            : NotebookVersioning.ComputeVersion(JsonSerializer.Deserialize<RawRecord>(json, JsonOptions)!.Xml);
+        if (actual != expected) {
+            throw new NotebookConflictException(key, expected, actual);
+        }
+    }
+
+    private static NotebookStorageEntry? TryDescribe(RawRecord record)
+    {
+        try {
+            return new NotebookStorageEntry(
+                record.Key,
+                NotebookVersioning.PeekTitle(record.Xml),
+                DateTimeOffset.Parse(record.SavedAt),
+                NotebookVersioning.ComputeVersion(record.Xml));
+        }
+        catch (XmlException) {
+            return null;
+        }
+    }
+
+    private static string NewKey() => Guid.NewGuid().ToString("N")[..12];
+
+    private sealed record RawRecord(string Key, string Xml, string SavedAt);
+
+    [JSImport("notebookGetAllJson", "main.js")]
+    [return: JSMarshalAs<JSType.Promise<JSType.String>>]
+    private static partial Task<string> GetAllJsonAsync();
+
+    [JSImport("notebookGetJson", "main.js")]
+    [return: JSMarshalAs<JSType.Promise<JSType.String>>]
+    private static partial Task<string?> GetJsonAsync(string key);
+
+    [JSImport("notebookPut", "main.js")]
+    [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
+    private static partial Task PutAsync(string key, string xml, string savedAt);
+
+    [JSImport("notebookRemove", "main.js")]
+    [return: JSMarshalAs<JSType.Promise<JSType.Void>>]
+    private static partial Task RemoveAsync(string key);
+}
+#endif

--- a/Sia.Examples/Elements/BrowserApplication.cs
+++ b/Sia.Examples/Elements/BrowserApplication.cs
@@ -8,19 +8,12 @@ public static class BrowserApplication
 {
     public static async Task RunAsync()
     {
-        // Notebooks live on WASMFS's default in-memory backend, not OPFS:
-        // wasmfs_create_opfs_backend() can deadlock waiting for its proxy
-        // worker to spawn (Emscripten's own docs warn about this), and it
-        // did hang the whole app boot in production. No mount call means no
-        // deadlock risk; the tradeoff is notebooks don't survive a reload.
-        const string NotebooksPath = "/notebooks";
-
         var mainThread = BrowserMainThread.Capture();
         var resources = new BrowserResourceLoader(mainThread);
         var frameworkAssemblies = new AssemblyLoader(mainThread, resources);
         var packages = new PackageReferenceLoader(resources);
 
-        var storage = new FileSystemNotebookStorage(NotebooksPath);
+        var storage = new IndexedDbNotebookStorage(mainThread);
         var library = new NotebookLibrary(storage);
         await library.RefreshAsync();
 

--- a/Sia.Examples/Logic/Storage/FileSystemNotebookStorage.cs
+++ b/Sia.Examples/Logic/Storage/FileSystemNotebookStorage.cs
@@ -1,15 +1,11 @@
-using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
-using System.Xml.Linq;
 
 namespace Sia_Examples.Notebook;
 
 public sealed class FileSystemNotebookStorage(string rootPath) : INotebookStorage
 {
     private const string Extension = ".notebook.xml";
-
-    private const int VersionLength = 12;
 
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
@@ -83,18 +79,9 @@ public sealed class FileSystemNotebookStorage(string rootPath) : INotebookStorag
 
     private static string NewKey() => Guid.NewGuid().ToString("N")[..12];
 
-    private static string PeekTitle(string xml)
-    {
-        using var reader = new StringReader(xml);
-        var document = XDocument.Load(reader, LoadOptions.None);
-        return (string?)document.Root?.Attribute("Title") ?? "";
-    }
+    private static string PeekTitle(string xml) => NotebookVersioning.PeekTitle(xml);
 
-    private static string ComputeVersion(string xml)
-    {
-        var hash = SHA256.HashData(Utf8NoBom.GetBytes(xml));
-        return Convert.ToHexStringLower(hash)[..VersionLength];
-    }
+    private static string ComputeVersion(string xml) => NotebookVersioning.ComputeVersion(xml);
 
     private static ValueTask<T> RunAsync<T>(Func<T> body, CancellationToken cancellationToken)
         => new(Task.Run(body, cancellationToken));

--- a/Sia.Examples/Logic/Storage/NotebookVersioning.cs
+++ b/Sia.Examples/Logic/Storage/NotebookVersioning.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Sia_Examples.Notebook;
+
+internal static class NotebookVersioning
+{
+    private const int VersionLength = 12;
+
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    public static string ComputeVersion(string xml)
+    {
+        var hash = SHA256.HashData(Utf8NoBom.GetBytes(xml));
+        return Convert.ToHexStringLower(hash)[..VersionLength];
+    }
+
+    public static string PeekTitle(string xml)
+    {
+        using var reader = new StringReader(xml);
+        var document = XDocument.Load(reader, LoadOptions.None);
+        return (string?)document.Root?.Attribute("Title") ?? "";
+    }
+}

--- a/Sia.Examples/Sia.Examples.Browser.csproj
+++ b/Sia.Examples/Sia.Examples.Browser.csproj
@@ -14,7 +14,6 @@
     <WasmEnableSIMD>true</WasmEnableSIMD>
     <WasmEnableWebcil>false</WasmEnableWebcil>
     <WasmEnableThreads>true</WasmEnableThreads>
-    <EmccExtraLDFlags>-sALLOW_MEMORY_GROWTH -sWASMFS=1</EmccExtraLDFlags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,9 +39,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Target Name="AddBrowserNativeModules" BeforeTargets="_GenerateManagedToNative" DependsOnTargets="PrepareForWasmBuildNative">
-    <ItemGroup>
-      <_WasmPInvokeModules Include="__Internal_emscripten" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Sia.Examples/wwwroot/main.js
+++ b/Sia.Examples/wwwroot/main.js
@@ -405,6 +405,60 @@ async function fetchText(url) {
   return new TextDecoder().decode(await loadBytes(url));
 }
 
+const NOTEBOOK_DB_NAME = 'sia-notebooks';
+const NOTEBOOK_DB_VERSION = 1;
+const NOTEBOOK_STORE = 'notebooks';
+
+let notebookDbPromise;
+
+function openNotebookDb() {
+  notebookDbPromise ??= new Promise((resolve, reject) => {
+    const request = indexedDB.open(NOTEBOOK_DB_NAME, NOTEBOOK_DB_VERSION);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(NOTEBOOK_STORE)) {
+        request.result.createObjectStore(NOTEBOOK_STORE, { keyPath: 'key' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  return notebookDbPromise;
+}
+
+function withNotebookStore(mode, op) {
+  return openNotebookDb().then(db => new Promise((resolve, reject) => {
+    const tx = db.transaction(NOTEBOOK_STORE, mode);
+    const store = tx.objectStore(NOTEBOOK_STORE);
+    let result;
+    const request = op(store);
+    if (request) {
+      request.onsuccess = () => { result = request.result; };
+      request.onerror = () => reject(request.error);
+    }
+    tx.oncomplete = () => resolve(result);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error('IndexedDB transaction aborted'));
+  }));
+}
+
+async function notebookGetAllJson() {
+  const records = await withNotebookStore('readonly', store => store.getAll());
+  return JSON.stringify(records ?? []);
+}
+
+async function notebookGetJson(key) {
+  const record = await withNotebookStore('readonly', store => store.get(key));
+  return record ? JSON.stringify(record) : null;
+}
+
+async function notebookPut(key, xml, savedAt) {
+  await withNotebookStore('readwrite', store => store.put({ key, xml, savedAt }));
+}
+
+async function notebookRemove(key) {
+  await withNotebookStore('readwrite', store => store.delete(key));
+}
+
 function lineOf(surface, node) {
   for (let current = node; current && current !== surface; current = current.parentNode) {
     if (current.nodeType === Node.ELEMENT_NODE && current.dataset?.ln !== undefined) {
@@ -1370,6 +1424,10 @@ setModuleImports('main.js', {
   },
   fetchBase64,
   fetchText,
+  notebookGetAllJson,
+  notebookGetJson,
+  notebookPut,
+  notebookRemove,
   reportError: message => console.error(message),
 });
 


### PR DESCRIPTION
Stacked on #92.

Restores notebook persistence after #92 dropped the OPFS mount entirely. Tried harder to make OPFS survivable first (deferred mount after first paint, timeout races on both Task/ThreadPool and raw OS threads) — every attempt failed the same way: once wasmfs_create_opfs_backend()/wasmfs_create_directory() wedges, it doesn't just block its own thread, it stalls the whole runtime's ability to schedule anything else, including an unrelated Thread.Sleep-based timeout on its own dedicated thread. Not fixable from managed code with the Emscripten version this SDK currently bundles.

IndexedDbNotebookStorage replaces FileSystemNotebookStorage for the browser target: plain JS interop (notebookGetAllJson/notebookGetJson/notebookPut/notebookRemove, added to wwwroot/main.js's existing setModuleImports block) talking directly to IndexedDB, no native WASMFS/OPFS binding involved anywhere. Versioning/title-parsing/conflict-detection logic extracted to NotebookVersioning so FileSystemNotebookStorage (still used by the console target) and this share one implementation.

Verified end-to-end via headless Playwright: create notebook → rename → save → full page reload → reopen → content intact, zero console errors throughout.