### PR TITLE
Replace ambient World.Current with explicit world ownership

### DIFF
--- a/Sia.Benchmarks/Reactors/MapperBenchmarks.cs
+++ b/Sia.Benchmarks/Reactors/MapperBenchmarks.cs
@@ -20,7 +20,6 @@ public class MapperBenchmarks
     public void Setup()
     {
         _world = new World();
-        Context<World>.Current = _world;
         _mapper = _world.AcquireAddon<Mapper<int>>();
         _entities = new Entity[EntityCount];
         for (var i = 0; i < EntityCount; i++) {
@@ -37,9 +36,6 @@ public class MapperBenchmarks
     [GlobalCleanup]
     public void Cleanup()
     {
-        if (ReferenceEquals(Context<World>.Current, _world)) {
-            Context<World>.Current = null;
-        }
         _world.Dispose();
     }
 

--- a/Sia.CodeGenerators/SiaPropertyGenerator.cs
+++ b/Sia.CodeGenerators/SiaPropertyGenerator.cs
@@ -474,7 +474,7 @@ internal partial class SiaPropertyGenerator : IIncrementalGenerator
         source.WriteLine("{");
         source.Indent++;
 
-        source.WriteLine("private readonly global::Sia.World _world = world ?? global::Sia.Context<global::Sia.World>.Current!;");
+        source.WriteLine("private readonly global::Sia.World _world = world ?? entity.Host?.World ?? throw new global::System.InvalidOperationException(\"The entity is not attached to a world.\");");
         source.Write("private readonly ref ");
         WriteComponentType();
         source.Write(" _component = ref entity.Get<");

--- a/Sia.Examples/Logic/Runner/NotebookProgramBuilder.cs
+++ b/Sia.Examples/Logic/Runner/NotebookProgramBuilder.cs
@@ -40,7 +40,6 @@ public static class NotebookProgramBuilder
         }
 
         Emit("var world = new global::Sia.World();\n");
-        Emit("global::Sia.Context<global::Sia.World>.Current = world;\n");
         Emit("try {\n");
 
         for (var index = 0; index < splits.Count; index++) {
@@ -71,7 +70,6 @@ public static class NotebookProgramBuilder
 
         Emit("}\n");
         Emit("finally {\n");
-        Emit("global::Sia.Context<global::Sia.World>.Current = null;\n");
         Emit("world.Dispose();\n");
         Emit("}\n");
 

--- a/Sia.Tests/Reactors/AggregatorTests.cs
+++ b/Sia.Tests/Reactors/AggregatorTests.cs
@@ -18,7 +18,6 @@ public class AggregatorTests(AggregatorTests.AggregatorContext context) : IClass
         public AggregatorContext()
         {
             World = new World();
-            Context<World>.Current = World;
 
             Aggregator = World.AcquireAddon<Aggregator<ObjectId>>();
         }

--- a/Sia.Tests/Reactors/HierarchyTests.cs
+++ b/Sia.Tests/Reactors/HierarchyTests.cs
@@ -20,7 +20,6 @@ public class HierarchyTests(HierarchyTests.HierarchyContext context) : IClassFix
         public HierarchyContext()
         {
             World = new World();
-            Context<World>.Current = World;
 
             Hierarchy = World.AcquireAddon<Hierarchy<TestTag>>();
         }

--- a/Sia.Tests/Reactors/MapperTests.cs
+++ b/Sia.Tests/Reactors/MapperTests.cs
@@ -18,7 +18,6 @@ public class MapperTests(MapperTests.MapperContext context) : IClassFixture<Mapp
         public MapperContext()
         {
             World = new World();
-            Context<World>.Current = World;
 
             Mapper = World.AcquireAddon<Mapper<ObjectId>>();
         }

--- a/Sia.Tests/Systems/ExtractSystemTests.cs
+++ b/Sia.Tests/Systems/ExtractSystemTests.cs
@@ -223,7 +223,6 @@ public class ExtractSystemTests
     public void ExtractSystemBase_FallsBackToSameWorldWithoutSubWorld()
     {
         using var world = new World();
-        Context<World>.Current = world;
         world.Create(HList.From(new Health(50)));
         world.Create(HList.From(new Health(60)));
 
@@ -266,7 +265,6 @@ public class ExtractSystemTests
     public void SnapshotExtractSystem_FreezesDataDoesNotSeeLaterMutations()
     {
         using var world = new World();
-        Context<World>.Current = world;
         world.Create(HList.From(new Health(100)));
         world.Create(HList.From(new Health(200)));
 
@@ -293,7 +291,6 @@ public class ExtractSystemTests
     public void SnapshotExtractSystem_UsesOwnWorldWithoutSubWorldContext()
     {
         using var world = new World();
-        Context<World>.Current = world;
         world.Create(HList.From(new Health(42)));
 
         var system = new HealthSnapshotSystem();
@@ -311,7 +308,6 @@ public class ExtractSystemTests
     public void SnapshotExtractSystem_GameThreadExtractsRenderThreadRenders()
     {
         using var world = new World();
-        Context<World>.Current = world;
 
         const int entityCount = 100;
         const int frameCount = 30;
@@ -348,7 +344,6 @@ public class ExtractSystemTests
     public void SnapshotExtractSystem_StressConcurrentExtractAndRender()
     {
         using var world = new World();
-        Context<World>.Current = world;
 
         const int entityCount = 100;
         const int frameCount = 30;
@@ -444,7 +439,6 @@ public class ExtractSystemTests
     public void ExtractSystem_AllMechanismsWorkTogether()
     {
         using var parent = new World();
-        Context<World>.Current = parent;
         parent.Create(HList.From(new Health(100), new Damage(10)));
         parent.Create(HList.From(new Health(200), new Damage(20)));
 
@@ -497,7 +491,6 @@ public class ExtractSystemTests
     public void ExtractSystem_ConcurrentSnapshotAndChannel()
     {
         using var world = new World();
-        Context<World>.Current = world;
         world.Create(HList.From(new FrameCounter(0)));
 
         var snapshot = new FrameSnapshotSystem();

--- a/Sia.Tests/WorldFixture.cs
+++ b/Sia.Tests/WorldFixture.cs
@@ -15,7 +15,6 @@ public class WorldFixture : IDisposable
     public WorldFixture()
     {
         World = new World();
-        Context<World>.Current = World;
     }
 
     public void Prepare<T1>(in T1 item1, int count, bool padding = true)

--- a/Sia/Systems/ExtractSystemBase.cs
+++ b/Sia/Systems/ExtractSystemBase.cs
@@ -30,8 +30,8 @@ public abstract class ExtractSystemBase(
 
     public override void Initialize(World world)
     {
-        _parentWorld = world.TryGetAddon<SubWorldContext>(out var ctx)
-            ? ctx.Parent
+        _parentWorld = world.TryGetAddon<IWorldSource>(out var source)
+            ? source.Source
             : world;
         _ownsParentQuery = extractMatcher is not null && extractMatcher != Matchers.Any;
 

--- a/Sia/Systems/SnapshotExtractSystem.cs
+++ b/Sia/Systems/SnapshotExtractSystem.cs
@@ -21,8 +21,8 @@ public abstract class SnapshotExtractSystem<TExtract> : SystemBase
 
     public override void Initialize(World world)
     {
-        _extractWorld = world.TryGetAddon<SubWorldContext>(out var ctx)
-            ? ctx.Parent
+        _extractWorld = world.TryGetAddon<IWorldSource>(out var source)
+            ? source.Source
             : world;
     }
 

--- a/Sia/Worlds/Extensions/EntityWorldContextExtensions.cs
+++ b/Sia/Worlds/Extensions/EntityWorldContextExtensions.cs
@@ -7,16 +7,16 @@ public static class EntityWorldContextExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Send<TEvent>(this Entity entity, in TEvent e)
         where TEvent : IEvent
-        => World.Current.Send(entity, e);
+        => EntityWorldOwner.Require(entity).Send(entity, e);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Execute<TCommand>(this Entity entity, in TCommand command)
         where TCommand : ICommand
-        => World.Current.Execute(entity, command);
+        => EntityWorldOwner.Require(entity).Execute(entity, command);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Execute<TComponent, TCommand>(
         this Entity entity, ref TComponent component, in TCommand command)
         where TCommand : ICommand<TComponent>
-        => World.Current.Execute(entity, ref component, command);
+        => EntityWorldOwner.Require(entity).Execute(entity, ref component, command);
 }

--- a/Sia/Worlds/Extensions/EntityWorldOwner.cs
+++ b/Sia/Worlds/Extensions/EntityWorldOwner.cs
@@ -1,0 +1,16 @@
+namespace Sia;
+
+using System.Runtime.CompilerServices;
+
+internal static class EntityWorldOwner
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static World? TryGet(Entity entity)
+        => entity.Host?.World;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static World Require(Entity entity)
+        => TryGet(entity)
+            ?? throw new InvalidOperationException(
+                "The entity is not attached to a world.");
+}

--- a/Sia/Worlds/Interfaces/IWorldEntity.cs
+++ b/Sia/Worlds/Interfaces/IWorldEntity.cs
@@ -1,0 +1,7 @@
+namespace Sia;
+
+public interface IWorldEntity
+{
+    World World { get; }
+    Entity Entity { get; }
+}

--- a/Sia/Worlds/Interfaces/IWorldSource.cs
+++ b/Sia/Worlds/Interfaces/IWorldSource.cs
@@ -1,0 +1,6 @@
+namespace Sia;
+
+public interface IWorldSource : IAddon
+{
+    World Source { get; }
+}

--- a/Sia/Worlds/SubWorld.cs
+++ b/Sia/Worlds/SubWorld.cs
@@ -2,9 +2,10 @@ namespace Sia;
 
 using System.Runtime.CompilerServices;
 
-public sealed class SubWorldContext : IAddon
+public sealed class SubWorldContext(World parent) : IAddon, IWorldSource
 {
-    public World Parent { get; set; } = null!;
+    public World Parent { get; } = parent;
+    public World Source => Parent;
 }
 
 public sealed class SubWorld : IDisposable
@@ -20,8 +21,7 @@ public sealed class SubWorld : IDisposable
         Parent = parent;
         World = new World();
 
-        var context = World.AddAddon<SubWorldContext>();
-        context.Parent = parent;
+        World.AddAddon(new SubWorldContext(parent));
     }
 
     ~SubWorld()
@@ -31,7 +31,17 @@ public sealed class SubWorld : IDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Tick(SystemStage stage, CancellationToken cancellation = default)
-        => stage.Tick(cancellation);
+    {
+        ArgumentNullException.ThrowIfNull(stage);
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+
+        if (!ReferenceEquals(stage.World, World)) {
+            throw new ArgumentException(
+                "The stage was created for a different world.", nameof(stage));
+        }
+
+        stage.Tick(cancellation);
+    }
 
     public void Dispose()
     {

--- a/Sia/Worlds/World.Addon.cs
+++ b/Sia/Worlds/World.Addon.cs
@@ -39,15 +39,24 @@ public partial class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public TAddon AddAddon<TAddon>()
         where TAddon : class, IAddon, new()
+        => AddAddon(new TAddon());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public TAddon AddAddon<TAddon>(TAddon addon)
+        where TAddon : class, IAddon
     {
-        ref var addon = ref _addons[WorldAddonIndexer<TAddon>.Index];
-        if (addon != null) {
+        ArgumentNullException.ThrowIfNull(addon);
+
+        ref var slot = ref _addons[WorldAddonIndexer<TAddon>.Index];
+        if (slot != null) {
             throw new Exception("Addon already exists: " + typeof(TAddon));
         }
-        var newAddon = CreateAddon<TAddon>();
-        addon = newAddon;
-        OnAddonCreated?.Invoke(newAddon);
-        return newAddon;
+
+        addon.OnInitialize(this);
+        slot = addon;
+        _addonCount++;
+        OnAddonCreated?.Invoke(addon);
+        return addon;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Sia/Worlds/World.cs
+++ b/Sia/Worlds/World.cs
@@ -64,4 +64,13 @@ public sealed partial class World : IReactiveEntityQuery, IEventSender
         command.Execute(this, target, ref component);
         Dispatcher.Send(target, command);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public WorldEntity Spawn()
+        => new(this, this.Create());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public WorldEntity Spawn<TEntity>(in TEntity initial)
+        where TEntity : struct, IHList
+        => new(this, this.Create(initial));
 }

--- a/Sia/Worlds/World.cs
+++ b/Sia/Worlds/World.cs
@@ -4,8 +4,6 @@ using System.Runtime.CompilerServices;
 
 public sealed partial class World : IReactiveEntityQuery, IEventSender
 {
-    public static World Current => Context.Get<World>();
-
     public event Action<World>? OnDisposed;
 
     public int Count { get; internal set; }

--- a/Sia/Worlds/WorldEntity.cs
+++ b/Sia/Worlds/WorldEntity.cs
@@ -1,0 +1,54 @@
+namespace Sia;
+
+using System.Runtime.CompilerServices;
+
+public readonly record struct WorldEntity(World World, Entity Entity) : IWorldEntity
+{
+    public EntityId Id => Entity.Id;
+    public bool IsValid => Entity.IsValid;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref TComponent Get<TComponent>()
+        => ref Entity.Get<TComponent>();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public WorldEntity Add<TComponent>(in TComponent initial)
+    {
+        Entity.Add(initial);
+        return this;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public WorldEntity Set<TComponent>(in TComponent value)
+    {
+        Entity.Set(value);
+        return this;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public WorldEntity Remove<TComponent>(out bool success)
+    {
+        Entity.Remove<TComponent>(out success);
+        return this;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Destroy()
+        => Entity.Destroy();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Send<TEvent>(in TEvent e)
+        where TEvent : IEvent
+        => World.Send(Entity, e);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Execute<TCommand>(in TCommand command)
+        where TCommand : ICommand
+        => World.Execute(Entity, command);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Execute<TComponent, TCommand>(
+        ref TComponent component, in TCommand command)
+        where TCommand : ICommand<TComponent>
+        => World.Execute(Entity, ref component, command);
+}


### PR DESCRIPTION
Resolve an entity's world from its host, add WorldEntity handles, and give sub-worlds an immutable IWorldSource parent.