### PR TITLE
Apply queued commands from other threads at each tick boundary

### DIFF
--- a/Sia/Systems/Scheduler.cs
+++ b/Sia/Systems/Scheduler.cs
@@ -273,6 +273,8 @@ public sealed class Scheduler : IAddon, IDisposable
                 }
                 _phase = SchedulerPhase.BeginTick;
             }
+
+            context.World.Commands.Apply(context.World);
         }
         finally {
             _phase = SchedulerPhase.Idle;
@@ -300,6 +302,8 @@ public sealed class Scheduler : IAddon, IDisposable
                 _phase = SchedulerPhase.Executing;
                 TickSlot(slot, context);
             }
+
+            context.World.Commands.Apply(context.World);
         }
         finally {
             _phase = SchedulerPhase.Idle;

--- a/Sia/Systems/SystemStage.cs
+++ b/Sia/Systems/SystemStage.cs
@@ -506,6 +506,7 @@ public sealed class SystemStage : ISystemScheduleEntry, IDisposable
         ObjectDisposedException.ThrowIf(IsDisposed, this);
         var context = new WorldContext(World, cancellation);
         _combinedAction(context);
+        World.Commands.Apply(World);
     }
 
     private static Outcome<Exception> CleanupInitialized(

--- a/Sia/Worlds/Commands/WorldCommandQueue.cs
+++ b/Sia/Worlds/Commands/WorldCommandQueue.cs
@@ -1,0 +1,37 @@
+namespace Sia;
+
+using System.Collections.Concurrent;
+
+public readonly record struct CommandRequest(Entity Target, ICommand Command)
+{
+    public readonly void Apply(World world)
+        => world.Execute(Target, Command);
+}
+
+public interface IWorldCommandQueue
+{
+    int Count { get; }
+
+    void Enqueue(in CommandRequest request);
+    int Apply(World world);
+}
+
+public sealed class WorldCommandQueue : IWorldCommandQueue
+{
+    private readonly ConcurrentQueue<CommandRequest> _requests = new();
+
+    public int Count => _requests.Count;
+
+    public void Enqueue(in CommandRequest request)
+        => _requests.Enqueue(request);
+
+    public int Apply(World world)
+    {
+        var count = 0;
+        while (_requests.TryDequeue(out var request)) {
+            request.Apply(world);
+            count++;
+        }
+        return count;
+    }
+}

--- a/Sia/Worlds/World.cs
+++ b/Sia/Worlds/World.cs
@@ -11,6 +11,7 @@ public sealed partial class World : IReactiveEntityQuery, IEventSender
     public int Version { get; internal set; }
 
     public WorldDispatcher Dispatcher { get; }
+    public IWorldCommandQueue Commands { get; } = new WorldCommandQueue();
 
     internal EntityStatePool EntityStates { get; } = new();
 


### PR DESCRIPTION
Add World.Commands, a thread-safe queue drained by SystemStage and Scheduler after every tick.