### PR TITLE
Guard world disposal against an incomplete bound actor

### DIFF
--- a/Sia/Worlds/Actor/WorldActor.cs
+++ b/Sia/Worlds/Actor/WorldActor.cs
@@ -311,4 +311,15 @@ public sealed class WorldActor : IDisposable
         Complete();
         GC.SuppressFinalize(this);
     }
+
+    public void CompleteAndDispose(TimeSpan timeout)
+    {
+        Complete();
+        if (!WaitForCompletion(timeout)) {
+            throw new TimeoutException(
+                $"WorldActor did not drain within {timeout}.");
+        }
+        ThrowIfFailed();
+        World.Dispose();
+    }
 }

--- a/Sia/Worlds/SubWorld.cs
+++ b/Sia/Worlds/SubWorld.cs
@@ -10,23 +10,28 @@ public sealed class SubWorldContext(World parent) : IAddon, IWorldSource
 
 public sealed class SubWorld : IDisposable
 {
+    public static TimeSpan DefaultActorDrainTimeout { get; } = TimeSpan.FromSeconds(5);
+
     public World Parent { get; }
 
     public World World { get; }
 
-    public bool IsDisposed { get; private set; }
+    public bool IsDisposed => World.IsDisposed;
 
-    public SubWorld(World parent)
+    private readonly TimeSpan _actorDrainTimeout;
+
+    public SubWorld(World parent, TimeSpan? actorDrainTimeout = null)
     {
         Parent = parent;
         World = new World();
+        _actorDrainTimeout = actorDrainTimeout ?? DefaultActorDrainTimeout;
 
         World.AddAddon(new SubWorldContext(parent));
     }
 
     ~SubWorld()
     {
-        DoDispose();
+        DoDispose(false);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -45,14 +50,20 @@ public sealed class SubWorld : IDisposable
 
     public void Dispose()
     {
-        DoDispose();
+        DoDispose(true);
         GC.SuppressFinalize(this);
     }
 
-    private void DoDispose()
+    private void DoDispose(bool disposing)
     {
         if (IsDisposed) { return; }
-        IsDisposed = true;
+
+        if (World.Actor is { IsCompleted: false } actor) {
+            if (!disposing) { return; }
+            actor.CompleteAndDispose(_actorDrainTimeout);
+            return;
+        }
+
         World.Dispose();
     }
 }

--- a/Sia/Worlds/World.cs
+++ b/Sia/Worlds/World.cs
@@ -30,6 +30,14 @@ public sealed partial class World : IReactiveEntityQuery, IEventSender
     private void Dispose(bool disposing)
     {
         if (IsDisposed) { return; }
+
+        if (disposing) {
+            ThrowIfActorIncomplete();
+        }
+        else if (_actor is { IsCompleted: false }) {
+            return;
+        }
+
         IsDisposed = true;
 
         Outcome<Exception>.Success
@@ -83,6 +91,15 @@ public sealed partial class World : IReactiveEntityQuery, IEventSender
         if (owner is not null && !ReferenceEquals(owner, this)) {
             throw new ArgumentException(
                 "The entity belongs to a different world.", nameof(target));
+        }
+    }
+
+    private void ThrowIfActorIncomplete()
+    {
+        if (_actor is { IsCompleted: false }) {
+            throw new InvalidOperationException(
+                "The world is bound to a WorldActor that has not completed. " +
+                "Call WorldActor.CompleteAndDispose(...) instead of World.Dispose() directly.");
         }
     }
 


### PR DESCRIPTION
World/SubWorld disposal used to race a still-processing bound WorldActor; now it fails loud (or cascades via CompleteAndDispose) instead of corrupting host buffers.