### PR TITLE
Fix actor runtime disposal and add scheduler-tick posting

### DIFF
--- a/Sia/Worlds/Actor/ActorRuntime.cs
+++ b/Sia/Worlds/Actor/ActorRuntime.cs
@@ -4,6 +4,8 @@ using System.Collections.Concurrent;
 
 public sealed class ActorRuntime : IDisposable
 {
+    public static TimeSpan DefaultDisposeTimeout { get; } = TimeSpan.FromSeconds(5);
+
     public int WorkerCount { get; }
     public int BatchSize { get; }
 
@@ -106,13 +108,24 @@ public sealed class ActorRuntime : IDisposable
     }
 
     public void Dispose()
+        => Dispose(DefaultDisposeTimeout);
+
+    public void Dispose(TimeSpan timeout)
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) {
             return;
         }
 
         _ready.Complete();
-        _blocking.Dispose();
+        _blocking.Dispose(timeout);
+
+#if !BROWSER
+        if (!Task.WaitAll(_workers, timeout)) {
+            throw new TimeoutException(
+                $"ActorRuntime workers did not stop within {timeout}.");
+        }
+#endif
+
         GC.SuppressFinalize(this);
     }
 
@@ -162,11 +175,22 @@ public sealed class ActorRuntime : IDisposable
         }
 
         public void Dispose()
+            => Dispose(DefaultDisposeTimeout);
+
+        public void Dispose(TimeSpan timeout)
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0) {
                 return;
             }
+
             _work.Complete();
+
+#if !BROWSER
+            if (!Task.WaitAll(_workers, timeout)) {
+                throw new TimeoutException(
+                    $"ActorRuntime blocking workers did not stop within {timeout}.");
+            }
+#endif
         }
     }
 }

--- a/Sia/Worlds/Actor/IWorldMessage.cs
+++ b/Sia/Worlds/Actor/IWorldMessage.cs
@@ -50,6 +50,34 @@ public sealed class TickMessage(SystemStage stage) : IWorldMessage
     }
 }
 
+public sealed class SchedulerTickMessage(Scheduler scheduler, ScheduleLabel? label = null)
+    : IWorldMessage
+{
+    private readonly TaskCompletionSource _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Scheduler Scheduler { get; } = scheduler;
+    public ScheduleLabel? Label { get; } = label;
+    public Task Completion => _completion.Task;
+
+    public void Execute(in WorldContext context)
+    {
+        try {
+            if (Label is { } label) {
+                Scheduler.TickSchedule(label, context.Cancellation);
+            }
+            else {
+                Scheduler.Tick(context.Cancellation);
+            }
+            _completion.TrySetResult();
+        }
+        catch (Exception error) {
+            _completion.TrySetException(error);
+            throw;
+        }
+    }
+}
+
 public sealed class CompleteMessage : IWorldMessage
 {
     public static CompleteMessage Instance { get; } = new();

--- a/Sia/Worlds/Actor/WorldActor.cs
+++ b/Sia/Worlds/Actor/WorldActor.cs
@@ -64,6 +64,9 @@ public sealed class WorldActor : IDisposable
     public void PostTick(SystemStage stage)
         => Post(new TickMessage(stage));
 
+    public void PostTickSchedule(Scheduler scheduler, ScheduleLabel? label = null)
+        => Post(new SchedulerTickMessage(scheduler, label));
+
     public void Complete()
     {
         lock (_gate) {

--- a/Sia/Worlds/World.Host.cs
+++ b/Sia/Worlds/World.Host.cs
@@ -105,7 +105,7 @@ public partial class World
         return false;
     }
 
-    public bool ConainsHost<THost>()
+    public bool ContainsHost<THost>()
         where THost : IEntityHost
         => _hosts.ContainsKey(WorldEntityHostIndexer<THost>.Index);
     


### PR DESCRIPTION
Fixes the ConainsHost typo and ActorRuntime.Dispose() never joining its worker threads; adds WorldActor.PostTickSchedule so a bound actor can drive a Scheduler, not just a raw SystemStage.