### PR TITLE
Fall back to per-element access for reference-typed entities

### DIFF
--- a/Sia/Entities/Hosts/BufferEntityHost.cs
+++ b/Sia/Entities/Hosts/BufferEntityHost.cs
@@ -32,6 +32,7 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
     public bool TryGetSequentialBytes(out Span<byte> bytes)
     {
         if (Buffer.Count == 0
+            || RuntimeHelpers.IsReferenceOrContainsReferences<TEntity>()
             || (long)Buffer.Count * Unsafe.SizeOf<TEntity>() > int.MaxValue) {
             bytes = default;
             return false;


### PR DESCRIPTION
Fixes #111. TryGetSequentialBytes now returns false for a TEntity containing references instead of letting MemoryMarshal.Cast throw, matching IEntityHost's default contract.