### PR TITLE
Extract QuerySubscription and add UseQuery/UseEvent hooks

### DIFF
--- a/Sia.Prelude/Reactive/Hooks.cs
+++ b/Sia.Prelude/Reactive/Hooks.cs
@@ -8,6 +8,8 @@ public ref struct Hooks
     private readonly Entity _cell;
     private StateCells? _states;
 
+    public readonly World World => _reconciler.World;
+
     internal Hooks(in ExpandContext context)
     {
         _reconciler = context.Reconciler;

--- a/Sia.Prelude/Reactive/HooksExtensions.cs
+++ b/Sia.Prelude/Reactive/HooksExtensions.cs
@@ -1,0 +1,116 @@
+namespace Sia.Reactive;
+
+using Sia.Reactors;
+
+public delegate void ReactiveQueryAction<TCapture>(
+    Entity entity,
+    scoped in TCapture capture)
+    where TCapture : struct;
+
+public delegate void ReactiveGlobalEventAction<TEvent, TCapture>(
+    Entity target,
+    scoped in TEvent @event,
+    scoped in TCapture capture)
+    where TEvent : IEvent
+    where TCapture : struct;
+
+public static class HooksExtensions
+{
+    private sealed class QueryActionState<TCapture>
+        where TCapture : struct
+    {
+        public TCapture Capture;
+        public ReactiveQueryAction<TCapture> OnAdded = null!;
+        public ReactiveQueryAction<TCapture> OnRemoved = null!;
+    }
+
+    private readonly record struct QueryDependencies<TCapture>(
+        World World,
+        HookRef<QueryActionState<TCapture>> State)
+        where TCapture : struct;
+
+    public static void UseQuery<TTypeUnion, TCapture>(
+        this ref Hooks hooks,
+        scoped in TCapture capture,
+        [NestedCallback] ReactiveQueryAction<TCapture> onAdded,
+        [NestedCallback] ReactiveQueryAction<TCapture> onRemoved)
+        where TTypeUnion : ITypeUnion, new()
+        where TCapture : struct
+    {
+        ArgumentNullException.ThrowIfNull(onAdded);
+        ArgumentNullException.ThrowIfNull(onRemoved);
+
+        var state = hooks.UseRef(static () => new QueryActionState<TCapture>());
+        state.Value.Capture = capture;
+        state.Value.OnAdded = onAdded;
+        state.Value.OnRemoved = onRemoved;
+
+        hooks.UseEffect(
+            new QueryDependencies<TCapture>(hooks.World, state),
+            static (in QueryDependencies<TCapture> deps) => {
+                var world = deps.World;
+                var state = deps.State;
+                return new QuerySubscription(
+                    world.Query<TTypeUnion>(),
+                    entity => {
+                        var s = state.Value;
+                        s.OnAdded(entity, s.Capture);
+                    },
+                    entity => {
+                        var s = state.Value;
+                        s.OnRemoved(entity, s.Capture);
+                    });
+            },
+            static (in QuerySubscription subscription) => subscription.Dispose());
+    }
+
+    private sealed class GlobalEventActionState<TEvent, TCapture>
+        where TEvent : IEvent
+        where TCapture : struct
+    {
+        public TCapture Capture;
+        public ReactiveGlobalEventAction<TEvent, TCapture> Action = null!;
+    }
+
+    private readonly record struct GlobalEventDependencies<TEvent, TCapture>(
+        World World,
+        HookRef<GlobalEventActionState<TEvent, TCapture>> State)
+        where TEvent : IEvent
+        where TCapture : struct;
+
+    private readonly record struct GlobalEventSubscription<TEvent>(
+        World World,
+        WorldDispatcher.Listener<TEvent> Listener)
+        where TEvent : IEvent;
+
+    public static void UseEvent<TEvent, TCapture>(
+        this ref Hooks hooks,
+        scoped in TCapture capture,
+        [NestedCallback] ReactiveGlobalEventAction<TEvent, TCapture> action)
+        where TEvent : IEvent
+        where TCapture : struct
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var state = hooks.UseRef(static () => new GlobalEventActionState<TEvent, TCapture>());
+        state.Value.Capture = capture;
+        state.Value.Action = action;
+
+        hooks.UseEffect(
+            new GlobalEventDependencies<TEvent, TCapture>(hooks.World, state),
+            static (in GlobalEventDependencies<TEvent, TCapture> deps) => {
+                var world = deps.World;
+                var state = deps.State;
+                bool Listener(Entity target, in TEvent e)
+                {
+                    var s = state.Value;
+                    s.Action(target, e, s.Capture);
+                    return false;
+                }
+                world.Dispatcher.Listen<TEvent>(Listener);
+                return new GlobalEventSubscription<TEvent>(world, Listener);
+            },
+            static (in GlobalEventSubscription<TEvent> subscription) =>
+                subscription.World.Dispatcher.Unlisten(subscription.Listener));
+    }
+}

--- a/Sia.Prelude/Reactors/Aggregator/Aggregator.cs
+++ b/Sia.Prelude/Reactors/Aggregator/Aggregator.cs
@@ -8,7 +8,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
     where TId : notnull, IEquatable<TId>
 {
     [AllowNull]
-    private IReactiveEntityQuery _aggregationQuery;
+    private QuerySubscription _aggregationSubscription;
     private readonly Dictionary<TId, Entity> _aggrs = [];
     private readonly Stack<HashSet<Entity>> _groupPool = new();
 
@@ -18,19 +18,16 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
     {
         base.OnInitialize(world);
 
-        _aggregationQuery = world.Query<TypeUnion<Aggregation<TId>>>();
-        _aggregationQuery.OnEntityHostAdded += host => {
-            host.OnEntityCreated += OnAggregationCreated;
-            host.OnEntityReleased += OnAggregationReleased;
-        };
+        _aggregationSubscription = new QuerySubscription(
+            world.Query<TypeUnion<Aggregation<TId>>>(),
+            OnAggregationCreated, OnAggregationReleased);
 
         Listen((Entity entity, in WorldEvents.Add<Aggregation<TId>> e) => {
             ref var aggr = ref entity.Get<Aggregation<TId>>();
             if (aggr.Aggregator != this) {
                 return;
             }
-            var group = _groupPool.TryPop(out var pooled) ? pooled : [];
-            aggr._group = group;
+            aggr._group ??= _groupPool.TryPop(out var pooled) ? pooled : [];
         });
 
         Listen((Entity entity, in WorldEvents.Remove<Aggregation<TId>> e) => {
@@ -53,21 +50,18 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
     {
         base.OnUninitialize(world);
 
-        foreach (var host in _aggregationQuery.Hosts) {
-            host.OnEntityCreated -= OnAggregationCreated;
-            host.OnEntityReleased -= OnAggregationReleased;
-        }
-
-        _aggregationQuery.Dispose();
-        _aggregationQuery = null;
+        _aggregationSubscription.Dispose();
+        _aggregationSubscription = null;
     }
 
     private void OnAggregationCreated(Entity entity)
     {
         ref var aggr = ref entity.Get<Aggregation<TId>>();
-        if (_aggrs.TryAdd(aggr.Id, entity)) {
-            aggr.Aggregator = this;
+        if (!_aggrs.TryAdd(aggr.Id, entity)) {
+            return;
         }
+        aggr.Aggregator = this;
+        aggr._group ??= _groupPool.TryPop(out var pooled) ? pooled : [];
     }
 
     private void OnAggregationReleased(Entity entity)
@@ -114,7 +108,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
 
             ref var aggr = ref aggrEntity.Get<Aggregation<TId>>();
             aggr.First = entity;
-            aggr._group = _groupPool.TryPop(out var pooled) ? pooled : [];
+            aggr._group ??= _groupPool.TryPop(out var pooled) ? pooled : [];
             aggr._group.Add(entity);
         }
         else {
@@ -144,6 +138,7 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
             var groupEntity = aggrEntity;
             _aggrs.Remove(id);
             _groupPool.Push(group);
+            aggr._group = null;
             groupEntity.Destroy();
         }
         else if (aggr.First == entity) {

--- a/Sia.Prelude/Reactors/Common/QuerySubscription.cs
+++ b/Sia.Prelude/Reactors/Common/QuerySubscription.cs
@@ -1,0 +1,47 @@
+namespace Sia.Reactors;
+
+public sealed class QuerySubscription : IDisposable
+{
+    public IReactiveEntityQuery Query { get; }
+
+    private readonly EntityHandler _onAdded;
+    private readonly EntityHandler _onRemoved;
+    private bool _disposed;
+
+    public QuerySubscription(
+        IReactiveEntityQuery query, EntityHandler onAdded, EntityHandler onRemoved)
+    {
+        Query = query;
+        _onAdded = onAdded;
+        _onRemoved = onRemoved;
+
+        Query.OnEntityHostAdded += OnHostAdded;
+        foreach (var host in Query.Hosts) {
+            OnHostAdded(host);
+        }
+    }
+
+    private void OnHostAdded(IReactiveEntityHost host)
+    {
+        host.OnEntityCreated += _onAdded;
+        host.OnEntityReleased += _onRemoved;
+
+        foreach (var entity in host) {
+            _onAdded(entity);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) {
+            return;
+        }
+        _disposed = true;
+
+        Query.OnEntityHostAdded -= OnHostAdded;
+        foreach (var host in Query.Hosts) {
+            host.OnEntityCreated -= _onAdded;
+            host.OnEntityReleased -= _onRemoved;
+        }
+    }
+}

--- a/Sia.Prelude/Reactors/Common/ReactorBase.cs
+++ b/Sia.Prelude/Reactors/Common/ReactorBase.cs
@@ -61,41 +61,22 @@ public abstract class ReactorBase<TTypeUnion> : ReactorBase
     protected IEntityMatcher Matcher { get; } = Matchers.From<TTypeUnion>();
 
     [AllowNull]
-    protected IReactiveEntityQuery Query { get; private set; }
+    protected IReactiveEntityQuery Query => _subscription?.Query!;
+
+    [AllowNull]
+    private QuerySubscription _subscription;
 
     public override void OnInitialize(World world)
     {
         base.OnInitialize(world);
-
-        Query = world.Query(Matcher);
-        Query.OnEntityHostAdded += OnEntityHostAdded;
-
-        foreach (var host in Query.Hosts) {
-            OnEntityHostAdded(host);
-        }
-    }
-
-    private void OnEntityHostAdded(IReactiveEntityHost host)
-    {
-        host.OnEntityCreated += OnEntityAdded;
-        host.OnEntityReleased += OnEntityRemoved;
-
-        foreach (var entity in host) {
-            OnEntityAdded(entity);
-        }
+        _subscription = new QuerySubscription(world.Query(Matcher), OnEntityAdded, OnEntityRemoved);
     }
 
     public override void OnUninitialize(World world)
     {
         base.OnUninitialize(world);
-
-        foreach (var host in Query.Hosts) {
-            host.OnEntityCreated -= OnEntityAdded;
-            host.OnEntityReleased -= OnEntityRemoved;
-        }
-
-        Query.Dispose();
-        Query = null;
+        _subscription.Dispose();
+        _subscription = null;
     }
 
     protected abstract void OnEntityAdded(Entity entity);

--- a/Sia.Prelude/Reactors/Hierarchy/Node.cs
+++ b/Sia.Prelude/Reactors/Hierarchy/Node.cs
@@ -31,6 +31,8 @@ public partial record struct Node<TTag>
     internal Entity? _prevParent;
     internal HashSet<Entity>? _children;
 
+    public Node() { }
+
     public Node(Entity? parent)
     {
         _parent = parent;


### PR DESCRIPTION
Pulls the repeated host-subscription boilerplate out of ReactorBase and AggregatorBase into a new QuerySubscription type under Sia.Prelude/Reactors/Common, then builds Hooks.UseQuery/UseEvent on top of that same type so reactive components can subscribe to reactor-style queries and world events the same way Reactors already do. Along the way it fixes QuerySubscription disposing the shared, matcher-cached World.Query(...) instance out from under any other subscriber holding the same query, tightens Aggregator's group pooling down to a single allocation and a single pool-return per entity (it was allocating up to three times and double-returning the same HashSet to the pool on removal), and gives Node<TTag> back an explicit parameterless constructor so its field defaults actually apply when constructed via new().