### PR TITLE
Subscribe aggregation tracking before the base entity replay

### DIFF
--- a/Sia.Prelude/Reactors/Aggregator/Aggregator.cs
+++ b/Sia.Prelude/Reactors/Aggregator/Aggregator.cs
@@ -14,10 +14,8 @@ public abstract class AggregatorBase<TId> : ReactorBase<TypeUnion<Sid<TId>>>
 
     public Aggregation<TId> this[in TId component] => _aggrs[component].Get<Aggregation<TId>>();
 
-    public override void OnInitialize(World world)
+    protected override void OnBeforeSubscribe(World world)
     {
-        base.OnInitialize(world);
-
         _aggregationSubscription = new QuerySubscription(
             world.Query<TypeUnion<Aggregation<TId>>>(),
             OnAggregationCreated, OnAggregationReleased);

--- a/Sia.Prelude/Reactors/Common/ReactorBase.cs
+++ b/Sia.Prelude/Reactors/Common/ReactorBase.cs
@@ -69,6 +69,7 @@ public abstract class ReactorBase<TTypeUnion> : ReactorBase
     public override void OnInitialize(World world)
     {
         base.OnInitialize(world);
+        OnBeforeSubscribe(world);
         _subscription = new QuerySubscription(world.Query(Matcher), OnEntityAdded, OnEntityRemoved);
     }
 
@@ -78,6 +79,8 @@ public abstract class ReactorBase<TTypeUnion> : ReactorBase
         _subscription.Dispose();
         _subscription = null;
     }
+
+    protected virtual void OnBeforeSubscribe(World world) {}
 
     protected abstract void OnEntityAdded(Entity entity);
     protected abstract void OnEntityRemoved(Entity entity);


### PR DESCRIPTION
Attaching an Aggregator to a world that already has matching Sid<TId> entities used to create one separate Aggregation entity per pre-existing entity instead of merging same-id entities into one, because ReactorBase replays those pre-existing entities before Aggregator's own subscription and event listeners are set up. Adds a protected OnBeforeSubscribe(World) hook to ReactorBase<TTypeUnion> that runs after the base class is initialized but before that replay fires, and moves Aggregator's subscription setup into an override of it, so pre-existing entities merge exactly like they would if created afterwards. Stacked on #113 since it builds on QuerySubscription.