### PR TITLE
Fire host create/release events on archetype migration

### DIFF
--- a/Sia/Worlds/WorldEntityHost.cs
+++ b/Sia/Worlds/WorldEntityHost.cs
@@ -155,9 +155,14 @@ public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost
     {
         InnerHost.MoveIn(entity, data);
         entity.GetStateUnchecked().Host = this;
+        OnEntityCreated?.Invoke(entity);
     }
 
-    public void MoveOut(Entity entity) => InnerHost.MoveOut(entity);
+    public void MoveOut(Entity entity)
+    {
+        OnEntityReleased?.Invoke(entity);
+        InnerHost.MoveOut(entity);
+    }
 
     public Entity GetEntity(int slot) => InnerHost.GetEntity(slot);
     public ref TEntity GetRef(int slot) => ref InnerHost.GetRef(slot);


### PR DESCRIPTION
WorldEntityHost.MoveIn/MoveOut never raised OnEntityCreated/OnEntityReleased, only Create/Release did, so any entity.Add<T>()/Remove<T>() that migrated an entity to a different archetype host was invisible to every IReactiveEntityHost consumer: ReactorBase, the new Hooks.UseQuery, and SystemStage's reactive/triggered query tracking could all end up silently holding onto entities that had already migrated away. This fires the same two events from MoveIn/MoveOut, mirroring Create/Release, without touching World.Count since no entity is actually created or destroyed. Stacked on #113 since it builds on QuerySubscription.