### PR TITLE
Allow unsafe code in notebook compilations

### DIFF
--- a/Sia.Examples/Logic/Runner/NotebookCompiler.cs
+++ b/Sia.Examples/Logic/Runner/NotebookCompiler.cs
@@ -23,7 +23,8 @@ public sealed class NotebookCompiler
     private readonly CSharpCompilationOptions _compilationOptions =
         new CSharpCompilationOptions(OutputKind.ConsoleApplication)
             .WithConcurrentBuild(false)
-            .WithNullableContextOptions(NullableContextOptions.Enable);
+            .WithNullableContextOptions(NullableContextOptions.Enable)
+            .WithAllowUnsafe(true);
 
     private NotebookProgram _program;
 


### PR DESCRIPTION
Enables WithAllowUnsafe on the notebook Roslyn compiler options so example notebook cells can use unsafe/pointer syntax. This is prep for an upcoming WebGPU demo cell that configures a surface and render pass directly through Sia.WebGPU's pointer-based API; the notebook content itself isn't included here yet.