### PR TITLE
Fix entity archetype migration to notify queries correctly

### DIFF
--- a/Sia.Prelude/Reactors/Common/QuerySubscription.cs
+++ b/Sia.Prelude/Reactors/Common/QuerySubscription.cs
@@ -1,5 +1,7 @@
 namespace Sia.Reactors;
 
+using System.Linq;
+
 public sealed class QuerySubscription : IDisposable
 {
     public IReactiveEntityQuery Query { get; }
@@ -25,8 +27,24 @@ public sealed class QuerySubscription : IDisposable
     {
         host.OnEntityCreated += _onAdded;
         host.OnEntityReleased += _onRemoved;
+        host.OnEntityMovedOut += HandleMovedOut;
+        host.OnEntityMovedIn += HandleMovedIn;
 
         foreach (var entity in host) {
+            _onAdded(entity);
+        }
+    }
+
+    private void HandleMovedOut(Entity entity, IReactiveEntityHost destination)
+    {
+        if (!Query.Hosts.Contains(destination)) {
+            _onRemoved(entity);
+        }
+    }
+
+    private void HandleMovedIn(Entity entity, IReactiveEntityHost source)
+    {
+        if (!Query.Hosts.Contains(source)) {
             _onAdded(entity);
         }
     }
@@ -42,6 +60,8 @@ public sealed class QuerySubscription : IDisposable
         foreach (var host in Query.Hosts) {
             host.OnEntityCreated -= _onAdded;
             host.OnEntityReleased -= _onRemoved;
+            host.OnEntityMovedOut -= HandleMovedOut;
+            host.OnEntityMovedIn -= HandleMovedIn;
         }
     }
 }

--- a/Sia/Entities/Delegates/EntityHandler.cs
+++ b/Sia/Entities/Delegates/EntityHandler.cs
@@ -2,6 +2,7 @@ namespace Sia;
 
 public delegate void EntityHandler(Entity entity);
 public delegate void EntityHandler<TData>(in TData data, Entity entity);
+public delegate void EntityMigrationHandler(Entity entity, IReactiveEntityHost counterpart);
 
 public delegate void SimpleEntityHandler(Entity entity);
 public delegate void SimpleEntityHandler<in TData>(TData data, Entity entity);

--- a/Sia/Entities/Hosts/BufferEntityHost.cs
+++ b/Sia/Entities/Hosts/BufferEntityHost.cs
@@ -84,7 +84,7 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
     public Entity GetEntity(int slot)
         => _entities[slot];
 
-    public void MoveOut(Entity entity)
+    public void MoveOut(Entity entity, IEntityHost destination)
         => MoveOut(entity.GetState());
 
     private void MoveOut(EntityState state)
@@ -105,7 +105,7 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
         Buffer.Count--;
     }
 
-    public void MoveIn(Entity entity, in TEntity data)
+    public void MoveIn(Entity entity, in TEntity data, IEntityHost source)
     {
         _ = entity.GetCurrentState();
         MoveInTrusted(entity, data);
@@ -142,10 +142,11 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
         }
         var state = entity.GetStateUnchecked();
         ref var data = ref Buffer.GetRef(state.Slot);
-        var host = state.Host!.GetSiblingHost<HList<TComponent, TEntity>>();
+        var host = state.Host!;
+        var siblingHost = host.GetSiblingHost<HList<TComponent, TEntity>>();
         var moved = HList.Cons(initial, data);
-        MoveOut(state);
-        host.MoveIn(entity, moved);
+        host.MoveOut(entity, siblingHost);
+        siblingHost.MoveIn(entity, moved, host);
     }
 
     private struct EntityMover(Entity e)
@@ -156,8 +157,8 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
         {
             var host = e.GetStateUnchecked().Host!;
             var siblingHost = host.GetSiblingHost<T>();
-            host.MoveOut(e);
-            siblingHost.MoveIn(e, data);
+            host.MoveOut(e, siblingHost);
+            siblingHost.MoveIn(e, data, host);
         }
     }
 
@@ -239,8 +240,8 @@ public class BufferEntityHost<TEntity, TBuffer>(TBuffer buffer)
             }
             var host = e.GetStateUnchecked().Host!;
             var siblingHost = host.GetSiblingHost<T>();
-            host.MoveOut(e);
-            siblingHost.MoveIn(e, value);
+            host.MoveOut(e, siblingHost);
+            siblingHost.MoveIn(e, value, host);
         }
     }
 

--- a/Sia/Entities/Interfaces/IEntityHost.cs
+++ b/Sia/Entities/Interfaces/IEntityHost.cs
@@ -17,7 +17,7 @@ public interface IEntityHost : IEnumerable<Entity>, IDisposable
 
     Entity Create();
     void Release(Entity entity);
-    void MoveOut(Entity entity);
+    void MoveOut(Entity entity, IEntityHost destination);
 
     Entity GetEntity(int slot);
     ref byte GetByteRef(int slot);
@@ -54,12 +54,14 @@ public interface IReactiveEntityHost : IEntityHost
 {
     event EntityHandler? OnEntityCreated;
     event EntityHandler? OnEntityReleased;
+    event EntityMigrationHandler? OnEntityMovedOut;
+    event EntityMigrationHandler? OnEntityMovedIn;
 }
 
 public interface IEntityHost<TEntity> : IEntityHost
     where TEntity : struct, IHList
 {
     Entity Create(in TEntity initial);
-    void MoveIn(Entity entity, in TEntity data);
+    void MoveIn(Entity entity, in TEntity data, IEntityHost source);
     ref TEntity GetRef(int slot);
 }

--- a/Sia/Systems/SystemStage.cs
+++ b/Sia/Systems/SystemStage.cs
@@ -98,8 +98,8 @@ public sealed class SystemStage : ISystemScheduleEntry, IDisposable
         public Entity GetEntity(int slot)
             => Host.GetEntity(_entities[slot].Slot);
 
-        public void MoveOut(Entity entity)
-            => Host.MoveOut(entity);
+        public void MoveOut(Entity entity, IEntityHost destination)
+            => Host.MoveOut(entity, destination);
 
         public void Add<TComponent>(Entity entity, in TComponent initial)
             => Host.Add(entity, initial);

--- a/Sia/Worlds/WorldEntityHost.cs
+++ b/Sia/Worlds/WorldEntityHost.cs
@@ -26,6 +26,8 @@ public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost
 
     public event EntityHandler? OnEntityCreated;
     public event EntityHandler? OnEntityReleased;
+    public event EntityMigrationHandler? OnEntityMovedOut;
+    public event EntityMigrationHandler? OnEntityMovedIn;
     public event Action<IEntityHost>? OnDisposed;
 
     public World World { get; } = world;
@@ -151,17 +153,21 @@ public sealed class WorldEntityHost<TEntity, TInnerHost>(World world, TInnerHost
         TList.HandleTypes(new ExEntityRemoveEventSender(entity, Descriptor, World.Dispatcher));
     }
 
-    public void MoveIn(Entity entity, in TEntity data)
+    public void MoveIn(Entity entity, in TEntity data, IEntityHost source)
     {
-        InnerHost.MoveIn(entity, data);
+        InnerHost.MoveIn(entity, data, source);
         entity.GetStateUnchecked().Host = this;
-        OnEntityCreated?.Invoke(entity);
+        if (source is IReactiveEntityHost reactiveSource) {
+            OnEntityMovedIn?.Invoke(entity, reactiveSource);
+        }
     }
 
-    public void MoveOut(Entity entity)
+    public void MoveOut(Entity entity, IEntityHost destination)
     {
-        OnEntityReleased?.Invoke(entity);
-        InnerHost.MoveOut(entity);
+        if (destination is IReactiveEntityHost reactiveDestination) {
+            OnEntityMovedOut?.Invoke(entity, reactiveDestination);
+        }
+        InnerHost.MoveOut(entity, destination);
     }
 
     public Entity GetEntity(int slot) => InnerHost.GetEntity(slot);


### PR DESCRIPTION
#115 fired OnEntityCreated/OnEntityReleased from WorldEntityHost.MoveIn/MoveOut, so hopping between two archetypes that both match a query looked like a real leave+join. For AggregatorBase/Hierarchy<TTag> that meant destroying (and cascading child-destroy for) live entities just from adding/removing an unrelated component.

- BufferEntityHost.Add<TComponent> now routes through the owning host's MoveOut like AddMany/Remove/RemoveMany already did.
- MoveOut/MoveIn now carry the counterpart host, firing new OnEntityMovedOut/OnEntityMovedIn instead of OnEntityCreated/OnEntityReleased for migrations.
- QuerySubscription checks Query.Hosts.Contains(counterpart) to decide synchronously whether a migration is a real exit/entry or just a hop.

Verified locally with a matrix of Add/Remove/AddMany on tracked entities, deleted before commit.